### PR TITLE
track page loads for albums

### DIFF
--- a/src/label_view.js
+++ b/src/label_view.js
@@ -197,7 +197,9 @@ chrome.extension.sendMessage({}, function(response) {
                     storeId(id.toString());
                     console.log("id is: ", id);
                 }
-                catch{}
+                catch(e){
+                    console.log(e);
+                }
             })
 
             $('.open-iframe').on('click', function(event){ fillframe(event); });

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -31,8 +31,8 @@ var storageLoadedPromise = new Promise(function(resolve, reject) {
         
         chrome.storage.sync.set({"previews": storageCache})
         console.log(storageCache)
+        resolve();
     });
-    resolve();
 });
 
 chrome.storage.sync.getBytesInUse("previews", function(bytesInUse) {

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -169,44 +169,40 @@ function generatePreview(id) {
 
 chrome.extension.sendMessage({}, function(response) {
 
-    var readyStateCheckInterval = setInterval(function() {
-        if (document.readyState === "complete") {
-            clearInterval(readyStateCheckInterval);
+    $( document ).ready(function() {
+        storageLoadedPromise.then(function() {
+            // iterate over page to get album IDs and append buttons with value
+            $('li[data-item-id]').each(function(index, item){
+                var id = $(item).closest('li').attr('data-item-id');
+                if (id.split("-")[0] == "album" || id.split("-")[0] == "track"){
+                    id = id.split("-")[1];
+                }
 
-            storageLoadedPromise.then(function() {
-                // iterate over page to get album IDs and append buttons with value
-                $('li[data-item-id]').each(function(index, item){
-                    var id = $(item).closest('li').attr('data-item-id');
-                    if (id.split("-")[0] == "album" || id.split("-")[0] == "track"){
-                        id = id.split("-")[1];
-                    }
-
-                    $preview_element = generatePreview(id);
-                    $(item).append($preview_element);
-                });
-
-                $('li[data-tralbumid][data-tralbumtype="a"]').each(function(index, item){
-                    var id = $(item).attr('data-tralbumid');
-                    
-                    $preview_element = generatePreview(id);
-                    $(item).append($preview_element);
-                });
-
-                // catched ID album pages
-                $('#pagedata').first().each(function(index, item){
-                    var data_blob = JSON.parse($(item).attr("data-blob"));
-                    try {
-                        var id = data_blob.fan_tralbum_data.tralbum_id;
-                        storeId(id.toString());
-                        console.log("id is: ", id);
-                    }
-                    catch{}
-                })
-
-                $('.open-iframe').on('click', function(event){ fillframe(event); });
-
-                $('.historybox').on('click', function(event) { boxclick(event); });
+                $preview_element = generatePreview(id);
+                $(item).append($preview_element);
             });
-        }
-    }, 10);
+
+            $('li[data-tralbumid][data-tralbumtype="a"]').each(function(index, item){
+                var id = $(item).attr('data-tralbumid');
+                
+                $preview_element = generatePreview(id);
+                $(item).append($preview_element);
+            });
+
+            // catched ID album pages
+            $('#pagedata').first().each(function(index, item){
+                var data_blob = JSON.parse($(item).attr("data-blob"));
+                try {
+                    var id = data_blob.fan_tralbum_data.tralbum_id;
+                    storeId(id.toString());
+                    console.log("id is: ", id);
+                }
+                catch{}
+            })
+
+            $('.open-iframe').on('click', function(event){ fillframe(event); });
+
+            $('.historybox').on('click', function(event) { boxclick(event); });
+        });
+    });
 });

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -193,7 +193,8 @@ chrome.extension.sendMessage({}, function(response) {
             $('#pagedata').first().each(function(index, item){
                 var datablob = JSON.parse($(item).attr("data-blob"));
                 try {
-                    var id = datablob.lo_querystr.split("item_id=")[1].split("&item_type=")[0]
+                    var urlParams = new URLSearchParams(datablob.lo_querystr);
+                    var id = urlParams.get('item_id');
                     if(id)
                     {
                         storeId(id.toString());

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,113 +1,134 @@
+// GLOBALS
+var pluginState = window.localStorage;
+
+var preview_id; // globally stores which 'preview' button was last clicked
+var preview_open = false; // globally stores if preveiw window is open
+
+var defaultData = {previewed: false}
+var data = {}
+
+chrome.storage.local.get('bandcamp', function(result) {
+   if(isEmpty(result)){
+       chrome.storage.local.set({'bandcamp': data})
+   }
+   else{
+       data = result
+   }
+});
+
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0;
+}
+
+function strBool(input){
+    if(input === "true")
+        return true;
+    return false;
+}
+
+function toggleHistorybox(target, state){
+    target.attr('class', "follow-unfollow historybox");
+    if(state)
+        $(target).attr('class', "follow-unfollow historybox following");
+    return target
+}
+
+// chrome.storage.onChanged.addListener(function(changes, namespace) {
+//     console.log("Chrome Storage Changed")
+//     for (var key in changes) {
+//       var storageChange = changes[key];
+//       for(var innerkey in storageChange.newValue){
+//           console.log(storageChange.newValue[innerkey])
+//       }
+//     }
+// });
+
+function boxclick(event)
+{
+    /*
+        tracks boxclicks to set pluginState for 'id'
+    */       
+    var id = $(event.target).parents('div').attr('id');
+    console.log(data)
+    data[[id]].previewed = !data[[id]].previewed
+    toggleHistorybox($(event.target), data[[id]].previewed)
+
+    chrome.storage.local.set({'bandcamp': data})
+}
+    
+function fillframe(event) {
+    $('.bclv-frame').html(''); // clear all iframes
+
+    var $bclv = $(event.target).parents('.music-grid-item').find('.bclv-frame');
+    var id = $bclv.attr('id');
+
+    // determine if preview window needs to be open
+    if (preview_open == true && preview_id == id){
+        preview_open = false;    
+    }
+    else {
+        preview_id = id;
+        preview_open = true;
+    }
+
+    if (preview_open) {
+        // preview opened, store this action in localstorage 'history'
+        // pluginState.setItem(id, true); // old way
+        // update state
+        data[[id]].previewed = true;
+
+        chrome.storage.local.set({'bandcamp': data})
+
+        // set checkbox to clicked
+        $checkbox = $(event.target).parents(`[id='${id}']`).find('.historybox');
+        $checkbox = toggleHistorybox($checkbox, true);
+
+        // fill frame
+        var url = 'https://bandcamp.com/EmbeddedPlayer/album='+id;
+        url = url + '/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=true/artwork=none/transparent=true/"';
+
+        var iframe_style = 'style="margin: 6px 0px 0px 0px; border: 0; width: 150%; height: 300px; position:relative; z-index:1;"';
+        var iframe_val = '<iframe '+iframe_style+' src='+url+' seamless></iframe>';
+        $bclv.html(iframe_val);
+    }
+}
+
+// helper function for creating preview button
+function generatePreview(id) {
+    $parent_div = $('<div>');
+    $parent_div.attr('id', id);
+
+    $button = $('<button>');
+    $button.attr('type', "button");
+    $button.attr('class', "follow-unfollow open-iframe");
+    $button.attr('style', "width: 90%");
+
+    $preview = $('<div>').html("Preview");
+    $button.append($preview);
+    
+    $bclvframe = $('<div>');
+    $bclvframe.attr('class', "bclv-frame").attr('id', id);
+
+    // add checkbox with stores history of clicks
+    $checkbox = $('<button>');
+    $checkbox.attr('style', "margin: 0px 0px 0px 5px; width: 28px; height: 28px; position: absolute;");
+    
+    if(!(id in data))
+        data[id] = defaultData
+    $checkbox = toggleHistorybox($checkbox, data[[id]].previewed);
+
+    $parent_div.append($button);
+    $parent_div.append($checkbox);
+    $parent_div.append($bclvframe);
+
+    return $parent_div
+}
+
 chrome.extension.sendMessage({}, function(response) {
- var pluginState = window.localStorage;
 
  var readyStateCheckInterval = setInterval(function() {
  if (document.readyState === "complete") {
     clearInterval(readyStateCheckInterval);
-
-    var preview_id; // globally stores which 'preview' button was last clicked
-    var preview_open = false; // globally stores if preveiw window is open
-    
-    function strBool(input){
-        /* 
-            converts string "true"/"false"
-            to bool
-        */
-        if(input === "true")
-            return true;
-        return false;
-    }
-
-    function toggleHistorybox(target, state){
-        target.attr('class', "follow-unfollow historybox");
-        if(state)
-            $(target).attr('class', "follow-unfollow historybox following");
-        return target
-    }
-
-    function boxclick(event){
-        /*
-            tracks boxclicks to set pluginState for 'id'
-        */       
-        // get ID // this may be a better place to store the ID
-        var $id = $(event.target).parents('div').attr('id');
-        var $boxstate = pluginState.getItem($id);
-        
-        // switch historybox look
-        $boxstate = !(strBool($boxstate))
-        toggleHistorybox($(event.target), $boxstate)
-        
-        // update state
-        pluginState.setItem($id, $boxstate);
-    }
-        
-    function fillframe(event) {
-        $('.bclv-frame').html(''); // clear all iframes
-
-        var $bclv = $(event.target).parents('.music-grid-item').find('.bclv-frame');
-        var id = $bclv.attr('id');
-
-        // determine if preview window needs to be open
-        if (preview_open == true && preview_id == id){
-            preview_open = false;    
-        }
-        else {
-            preview_id = id;
-            preview_open = true;
-        }
-
-        if (preview_open) {
-            // preview opened, store this action in localstorage 'history'
-            pluginState.setItem(id, true);
-
-            // set checkbox to clicked
-            $checkbox = $(event.target).parents(`[id='${id}']`).find('.historybox');
-            $checkbox = toggleHistorybox($checkbox, true);
-
-            // fill frame
-            var url = 'https://bandcamp.com/EmbeddedPlayer/album='+id;
-            url = url + '/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=true/artwork=none/transparent=true/"';
-
-            var iframe_style = 'style="margin: 6px 0px 0px 0px; border: 0; width: 150%; height: 300px; position:relative; z-index:1;"';
-            var iframe_val = '<iframe '+iframe_style+' src='+url+' seamless></iframe>';
-            $bclv.html(iframe_val);
-        }
-    }
-
-    // helper function for creating preview button
-    function generatePreview(id) {
-        // check if preview button has been pressed
-        if(pluginState.getItem(id) === null) {
-            pluginState.setItem(id, false);
-        }
-
-        $parent_div = $('<div>');
-        $parent_div.attr('id', id);
-
-        $button = $('<button>');
-        $button.attr('type', "button");
-        $button.attr('class', "follow-unfollow open-iframe");
-        $button.attr('style', "width: 90%");
-
-        $preview = $('<div>').html("Preview");
-        $button.append($preview);
-        
-        $bclvframe = $('<div>');
-        $bclvframe.attr('class', "bclv-frame").attr('id', id);
-
-        // add checkbox with stores history of clicks
-        $checkbox = $('<button>');
-        $checkbox.attr('style', "margin: 0px 0px 0px 5px; width: 28px; height: 28px; position: absolute;");
-        
-        $boxstate = strBool(pluginState.getItem(id));
-        $checkbox = toggleHistorybox($checkbox, $boxstate);
-
-        $parent_div.append($button);
-        $parent_div.append($checkbox);
-        $parent_div.append($bclvframe);
-
-        return $parent_div
-    }
 
     // iterate over page to get album IDs and append buttons with value
     $('li[data-item-id]').each(function(index, item){

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -201,7 +201,7 @@ chrome.extension.sendMessage({}, function(response) {
                     }
                 }
                 catch(e){
-                    console.log(e);
+                    console.error(e);
                 }
             })
 

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,4 +1,4 @@
-// console.log = function() {}; // disable logging
+console.log = function() {}; // disable logging
 
 var preview_id; // globally stores which 'preview' button was last clicked
 var preview_open = false; // globally stores if preveiw window is open

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,4 +1,4 @@
-console.log = function() {}; // disable logging
+// console.log = function() {}; // disable logging
 
 var preview_id; // globally stores which 'preview' button was last clicked
 var preview_open = false; // globally stores if preveiw window is open
@@ -8,30 +8,36 @@ var storageCache = []
 // load storage backed
 var storageLoadedPromise = new Promise(function(resolve, reject) {
     chrome.storage.sync.get("previews", function(result) {
-        // load storage
-        if(isEmpty(result)){
-            console.log("storage empty, storing new")
-            chrome.storage.sync.set({"previews": storageCache})
-        }
-        else{
-            console.log("storage exists, storing to variable 'storageCache'")
-            storageCache = result["previews"]
-        }
+        try{
+            // load storage
+            if(isEmpty(result)){
+                console.log("storage empty, storing new")
+                chrome.storage.sync.set({"previews": storageCache})
+            }
+            else{
+                console.log("storage exists, storing to variable 'storageCache'")
+                storageCache = result["previews"]
+            }
 
-        // migrate old storage
-        console.log("plugin state transfer")
-        var pluginState = window.localStorage;
-        Object.keys(pluginState).forEach(function(key) {
-        if(pluginState[key] === "true" && !(key.includes("-")))
-        {
-            console.log("storing key: ", key);
-            storeId(key);
+            // migrate old storage
+            console.log("plugin state transfer")
+            var pluginState = window.localStorage;
+            Object.keys(pluginState).forEach(function(key) {
+            if(pluginState[key] === "true" && !(key.includes("-")))
+            {
+                console.log("storing key: ", key);
+                storeId(key);
+            }
+            });
+            
+            chrome.storage.sync.set({"previews": storageCache})
+            console.log(storageCache)
+            resolve();
         }
-        });
-        
-        chrome.storage.sync.set({"previews": storageCache})
-        console.log(storageCache)
-        resolve();
+        catch(e) {
+            console.error(e);
+            reject(e);
+        }
     });
 });
 

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -191,11 +191,14 @@ chrome.extension.sendMessage({}, function(response) {
 
             // catched ID album pages
             $('#pagedata').first().each(function(index, item){
-                var data_blob = JSON.parse($(item).attr("data-blob"));
+                var datablob = JSON.parse($(item).attr("data-blob"));
                 try {
-                    var id = data_blob.fan_tralbum_data.tralbum_id;
-                    storeId(id.toString());
-                    console.log("id is: ", id);
+                    var id = datablob.lo_querystr.split("item_id=")[1].split("&item_type=")[0]
+                    if(id)
+                    {
+                        storeId(id.toString());
+                        console.log("id is: ", id);
+                    }
                 }
                 catch(e){
                     console.log(e);


### PR DESCRIPTION
previously, album "previews" were only recorded when the preview button was pushed (or when the preview icon was clicked). 

This feature now tracks album previews from album page loads. Basically, if you end up on the album's page that preview will be stored and reflected on the label page. 

This is enabled by changing the storage backend to the `google.storage` API. The `sync` version is used which allows the plugin to be used on multiple machines and stay in sync.