### PR TITLE
Feat/logging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     },
     "plugins": ["prettier"],
     "rules": {
-        "prettier/prettier": "error"
+        "prettier/prettier": "error",
+        "no-console": "error"
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,16 +34,27 @@ Different `npm` commands defined in the `scripts` section of `package.json` can 
 #### build
 run:
 
-```
+```sh
+# Defaults to --mode=production:
 npm run build
 ```
 this will generate js files in `./dist`.
 
+Continuous rebuild when files update:
+
+```sh
+# Defaults to --mode=development:
+npm run build:watch
+```
+
 #### linter
 
-run:
-```
+```sh
+# Show ESLint issues:
 npm run lint
+
+# Auto-fix ESLint issues, if possible:
+npm run lint:fix
 ```
 
 #### test
@@ -65,3 +76,13 @@ Testing documentation:
 - [Sinon-Chrome: Mock Chrome extension methods](https://github.com/acvetkov/sinon-chrome)
 - [Sinon: mocks, spies, assertions](https://sinonjs.org/releases/v9.0.2/assertions/)
 - [Karma test runner](https://karma-runner.github.io/)
+
+#### distribution
+
+run:
+
+```sh
+npm run package
+```
+
+This sets `NODE_ENV=production` which silences debug-level logging, and outputs a `.zip` file for distribution.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function(config) {
      * For slower machines you may need to have a longer browser
      * wait time . Uncomment the line below if required.
      */
-    // browserNoActivityTimeout: 30000
+    browserNoActivityTimeout: 300000,
 
     // 'karma-*' is default and loads all available plugins. Kept here
     // for visibility and to prevent accidental override.

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
@@ -1654,11 +1664,19 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1666,14 +1684,30 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1839,8 +1873,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -2236,6 +2269,11 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -2744,6 +2782,16 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -2905,6 +2953,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
       "version": "1.11.0",
@@ -3478,8 +3531,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -3777,8 +3829,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "4.0.6",
@@ -4291,6 +4342,11 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -4619,6 +4675,18 @@
         "flatted": "^2.0.1",
         "rfdc": "^1.1.4",
         "streamroller": "^2.2.4"
+      }
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
       }
     },
     "lolex": {
@@ -5058,8 +5126,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -5357,6 +5424,14 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -5811,8 +5886,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -6026,7 +6100,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6276,8 +6349,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6417,6 +6489,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
     },
     "sinon": {
       "version": "9.0.2",
@@ -6903,6 +6990,11 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7056,7 +7148,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -7271,6 +7362,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7388,6 +7484,11 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
       "version": "1.10.0",
@@ -7706,8 +7807,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -8177,6 +8277,53 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
+    },
+    "winston": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.2.tgz",
+      "integrity": "sha512-vTOrUZlyQPS8VpCcQ1JT8BumDAUe4awCHZ9nmGgO7LqkV4atj0dKa5suA7Trf7QKtBszE2yUs9d8744Kz9j4jQ==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "test": "npx karma start --single-run",
     "test:watch": "npx karma start",
-    "lint": "npx eslint ./src/",
+    "lint": "npx eslint ./src/ ./test/",
     "lint:fix": "npm run lint -- --fix",
     "build": "webpack --config webpack.config.js",
     "build:dev": "npm run build -- --mode=development",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Chrome extension adding extra features to the Bandcamp experience.",
   "dependencies": {
     "idb": "^5.0.3",
-    "jquery": "^3.5.0"
+    "jquery": "^3.5.0",
+    "winston": "^3.3.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -32,7 +33,10 @@
     "test": "npx karma start --single-run",
     "test:watch": "npx karma start",
     "lint": "npx eslint ./src/",
+    "lint:fix": "npm run lint -- --fix",
     "build": "webpack --config webpack.config.js",
+    "build:dev": "npm run build -- --mode=development",
+    "build:watch": "npm run build:dev -- --watch --progress",
     "clean": "rm -fr ./node_modules ./dist",
     "package": "npm run build && zip BandcampLabelView.zip LICENSE _locales/**/* icons/* dist/* manifest.json html/browser_action.html"
   },

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,6 @@
 import { openDB } from "idb";
+import Logger from "./logger";
+const log = new Logger();
 
 export async function getDB(storeName) {
   const dbName = "BandcampEnhancementSuite";
@@ -55,7 +57,9 @@ export async function setTrue(storeName, key, port) {
 
 export const init = () => {
   chrome.runtime.onConnect.addListener(function(port) {
-    console.assert(port.name == "bandcamplabelview");
+    if (port.name !== "bandcamplabelview") {
+      log.error(`Unexpected chrome.runtime.onConnect port name: ${port.name}`);
+    }
 
     // get values of initial
     port.onMessage.addListener(function(msg) {
@@ -79,7 +83,7 @@ export const init = () => {
           });
         }
       } catch (e) {
-        console.error(e);
+        log.error(e);
       }
     });
   });

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,9 +1,9 @@
 import $ from "jquery";
 import Logger from "./logger";
-const log = new Logger();
 
 export default class LabelView {
   constructor() {
+    this.log = new Logger();
     this.previewId; // globally stores which 'preview' button was last clicked
     this.previewOpen = false; // globally stores if preveiw window is open
 
@@ -25,7 +25,7 @@ export default class LabelView {
     });
 
     $(document).ready(() => {
-      log.info("Rendering DOM...");
+      this.log.info("Rendering DOM...");
       this.renderDom();
     });
   }

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,4 +1,6 @@
 import $ from "jquery";
+import Logger from "./logger";
+const log = new Logger();
 
 export default class LabelView {
   constructor() {
@@ -23,6 +25,7 @@ export default class LabelView {
     });
 
     $(document).ready(() => {
+      log.info("Rendering DOM...");
       this.renderDom();
     });
   }

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -7,14 +7,23 @@ export default class LabelView {
     this.previewId; // globally stores which 'preview' button was last clicked
     this.previewOpen = false; // globally stores if preveiw window is open
 
-    // connect to background
-    this.port = chrome.runtime.connect(null, { name: "bandcamplabelview" });
+    try {
+      // connect to background
+      this.port = chrome.runtime.connect(null, { name: "bandcamplabelview" });
 
-    // kickstart
-    this.port.onMessage.addListener(msg => {
-      if (msg.id) this.setHistory(msg.id.key, msg.id.value);
-    });
-
+      // kickstart
+      this.port.onMessage.addListener(msg => {
+        if (msg.id) this.setHistory(msg.id.key, msg.id.value);
+      });
+    } catch (e) {
+      if (e.message.includes("Error in invocation of runtime.connect")) {
+        // This only occurs in testing, ignoring for now
+        this.log.error(e);
+      } else {
+        // Ensure other errors are escalated
+        throw e;
+      }
+    }
     // migrates old local storage, will be deleted in future versions
     var pluginState = window.localStorage;
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,63 @@
+// Custom browser logger.
+// Only prints when NODE_ENV is not 'production'.
+// Inspiration: https://github.com/winstonjs/winston/issues/287#issuecomment-647196496
+//
+// Usage: https://github.com/winstonjs/winston#using-logging-levels
+//
+//   import logger from './logger';
+//   const log = new Logger();
+//   logger.debug('got here');
+//   logger.info({some: 'object'});
+//   logger.error('Production problem!');
+
+import * as winston from "winston";
+import { TransformableInfo } from "logform";
+import * as Transport from "winston-transport";
+
+// Customizing the Winston console transporter
+class Console extends Transport {
+  constructor(options = {}) {
+    super(options);
+
+    this.setMaxListeners(30);
+
+    // enumeration to assign color values to
+    this.levelColors = {
+      INFO: "darkturquoise",
+      DEBUG: "khaki",
+      ERROR: "tomato"
+    };
+
+    this.defaultColor = "color: inherit";
+  }
+
+  log(info, next) {
+    // styles a console log statement accordingly to the log level
+    // log level colors are taken from levelcolors enum
+    console.log(
+      `%c[%cBES ${info.level.toUpperCase()}%c]:`,
+      this.defaultColor,
+      `color: ${this.levelColors[info.level.toUpperCase()]};`,
+      this.defaultColor,
+      // message will be included after stylings
+      // through this objects and arrays will be expandable
+      info.message
+    );
+
+    // This is a stream, be sure to flow onward
+    next();
+  }
+}
+
+export default class Logger extends winston.createLogger {
+  constructor() {
+    // When in production, only show errors.
+    const transportLevel =
+      process.env.NODE_ENV == "production" ? "error" : "debug";
+
+    // Provide `winston.createLogger()` args as usual...
+    super({
+      transports: [new Console({ level: transportLevel })]
+    });
+  }
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -15,7 +15,7 @@ import { TransformableInfo } from "logform";
 import * as Transport from "winston-transport";
 
 // Customizing the Winston console transporter
-class Console extends Transport {
+class CustomConsole extends Transport {
   constructor(options = {}) {
     super(options);
 
@@ -51,14 +51,14 @@ class Console extends Transport {
 }
 
 export default class Logger extends winston.createLogger {
-  constructor() {
+  constructor(level) {
     // When in production, only show errors.
     const transportLevel =
-      process.env.NODE_ENV == "production" ? "error" : "debug";
+      level || process.env.NODE_ENV == "production" ? "error" : "debug";
 
     // Provide `winston.createLogger()` args as usual...
     super({
-      transports: [new Console({ level: transportLevel })]
+      transports: [new CustomConsole({ level: transportLevel })]
     });
   }
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,5 +1,5 @@
 // Custom browser logger.
-// Only prints when NODE_ENV is not 'production'.
+// Only prints errors when NODE_ENV is 'production'.
 // Inspiration: https://github.com/winstonjs/winston/issues/287#issuecomment-647196496
 //
 // Usage: https://github.com/winstonjs/winston#using-logging-levels

--- a/src/logger.js
+++ b/src/logger.js
@@ -34,6 +34,7 @@ class Console extends Transport {
   log(info, next) {
     // styles a console log statement accordingly to the log level
     // log level colors are taken from levelcolors enum
+    // eslint-disable-next-line no-console
     console.log(
       `%c[%cBES ${info.level.toUpperCase()}%c]:`,
       this.defaultColor,

--- a/test/background.js
+++ b/test/background.js
@@ -1,81 +1,81 @@
-import chai from 'chai';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai'
-import { assert, expect } from 'chai';
-import chrome from 'sinon-chrome';
+import chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { assert, expect } from "chai";
+import chrome from "sinon-chrome";
 chai.use(sinonChai);
 
-import * as bg from '../src/background.js';
+import * as bg from "../src/background.js";
 
 // Sinon-chrome doesn't handle ports, so let's make our own
-const mockPort = {postMessage: sinon.spy()};
+const mockPort = { postMessage: sinon.spy() };
 
 describe("Background", () => {
   // Global db setup for use in all tests
   let db;
   before(async () => {
-    db = await bg.getDB('testStore')
+    db = await bg.getDB("testStore");
   });
 
   describe("getDB()", () => {
-    it('should return an IDBDatabase', async () => {
+    it("should return an IDBDatabase", async () => {
       expect(db instanceof IDBDatabase).to.be.true;
     });
 
     it('should name the database "BandcampEnhancementSuite"', async () => {
-      expect(db.name).to.equal('BandcampEnhancementSuite');
+      expect(db.name).to.equal("BandcampEnhancementSuite");
     });
   });
 
   describe("setVal()", () => {
-    it('should set a db value', async () => {
-      await bg.setVal('testStore', 'testKey', 'testVal')
-      const fetched = await db.get('testStore', 'testVal')
-      expect(fetched).to.equal('testKey');
+    it("should set a db value", async () => {
+      await bg.setVal("testStore", "testKey", "testVal");
+      const fetched = await db.get("testStore", "testVal");
+      expect(fetched).to.equal("testKey");
     });
   });
 
   describe("getVal()", () => {
-    it('should get a db value', async () => {
-      await db.put('testStore', 'testVal2', 'testKey2')
-      const fetched = await bg.getVal('testStore', 'testKey2')
-      expect(fetched).to.equal('testVal2');
+    it("should get a db value", async () => {
+      await db.put("testStore", "testVal2", "testKey2");
+      const fetched = await bg.getVal("testStore", "testKey2");
+      expect(fetched).to.equal("testVal2");
     });
   });
 
   describe("query()", () => {
     describe("when key does not have a value", () => {
       beforeEach(async () => {
-        await db.delete('testStore', 'testKey')
+        await db.delete("testStore", "testKey");
       });
 
-      it('should set the DB key to false', async () => {
+      it("should set the DB key to false", async () => {
         // Initial check: confirm key is unset
-        const initialVal = await db.get('testStore', 'testKey')
+        const initialVal = await db.get("testStore", "testKey");
         expect(initialVal).to.be.undefined;
 
         // Confirm it gets set to false
-        await bg.query('testStore', 'testKey', mockPort)
-        const finalVal = await db.get('testStore', 'testKey')
+        await bg.query("testStore", "testKey", mockPort);
+        const finalVal = await db.get("testStore", "testKey");
         expect(finalVal).to.be.false;
       });
 
-      it('should postMessage with value=false', async () => {
-        await bg.query('testStore', 'testKey', mockPort)
+      it("should postMessage with value=false", async () => {
+        await bg.query("testStore", "testKey", mockPort);
         expect(mockPort.postMessage).to.be.calledWith({
-          id: { key: 'testKey', value: false }
+          id: { key: "testKey", value: false }
         });
       });
     });
 
     describe("when key has a value", () => {
-      it('should call portMessage with fetched value', async () => {
+      it("should call portMessage with fetched value", async () => {
         // Load expected value into key
-        await db.put('testStore', 'testVal', 'testKey')
+        await db.put("testStore", "testVal", "testKey");
 
-        await bg.query('testStore', 'testKey', mockPort)
+        await bg.query("testStore", "testKey", mockPort);
         expect(mockPort.postMessage).to.be.calledWith({
-          id: { key: 'testKey', value: 'testVal' }
+          id: { key: "testKey", value: "testVal" }
         });
       });
     });
@@ -85,17 +85,17 @@ describe("Background", () => {
     describe("when the value is true", () => {
       it("should set it to false", async () => {
         // Load expected value into key
-        await db.put('testStore', true, 'testKey')
-        await bg.toggle('testStore', 'testKey', mockPort)
-        const finalVal = await db.get('testStore', 'testKey')
-        expect(finalVal).to.be.false
+        await db.put("testStore", true, "testKey");
+        await bg.toggle("testStore", "testKey", mockPort);
+        const finalVal = await db.get("testStore", "testKey");
+        expect(finalVal).to.be.false;
       });
 
-      it('should postMessage with value=false', async () => {
-        await db.put('testStore', true, 'testKey')
-        await bg.toggle('testStore', 'testKey', mockPort)
+      it("should postMessage with value=false", async () => {
+        await db.put("testStore", true, "testKey");
+        await bg.toggle("testStore", "testKey", mockPort);
         expect(mockPort.postMessage).to.be.calledWith({
-          id: { key: 'testKey', value: false }
+          id: { key: "testKey", value: false }
         });
       });
     });
@@ -103,52 +103,52 @@ describe("Background", () => {
     describe("when the value is false", () => {
       it("should set it to true", async () => {
         // Load expected value into key
-        await db.put('testStore', false, 'testKey')
-        await bg.toggle('testStore', 'testKey', mockPort)
-        const finalVal = await db.get('testStore', 'testKey')
-        expect(finalVal).to.be.true
+        await db.put("testStore", false, "testKey");
+        await bg.toggle("testStore", "testKey", mockPort);
+        const finalVal = await db.get("testStore", "testKey");
+        expect(finalVal).to.be.true;
       });
 
-      it('should postMessage with value=true', async () => {
-        await db.put('testStore', false, 'testKey')
-        await bg.toggle('testStore', 'testKey', mockPort)
+      it("should postMessage with value=true", async () => {
+        await db.put("testStore", false, "testKey");
+        await bg.toggle("testStore", "testKey", mockPort);
         expect(mockPort.postMessage).to.be.calledWith({
-          id: { key: 'testKey', value: true }
+          id: { key: "testKey", value: true }
         });
       });
-    })
+    });
   });
 
   describe("setTrue()", () => {
     it("should set the key to true", async () => {
       // Pre-populate non-true value to ensure update
-      await db.put('testStore', false, 'testKey')
+      await db.put("testStore", false, "testKey");
 
-      await bg.setTrue('testStore', 'testKey', mockPort)
-      const finalVal = await db.get('testStore', 'testKey')
-      expect(finalVal).to.be.true
+      await bg.setTrue("testStore", "testKey", mockPort);
+      const finalVal = await db.get("testStore", "testKey");
+      expect(finalVal).to.be.true;
     });
 
-    it('should postMessage with value=true', async () => {
-      await bg.setTrue('testStore', 'testKey', mockPort)
+    it("should postMessage with value=true", async () => {
+      await bg.setTrue("testStore", "testKey", mockPort);
       expect(mockPort.postMessage).to.be.calledWith({
-        id: { key: 'testKey', value: true }
+        id: { key: "testKey", value: true }
       });
     });
   });
 
   describe("init()", () => {
     beforeEach(() => {
-        global.chrome = chrome;
+      global.chrome = chrome;
     });
 
     it("should call chrome.runtime.onConnect", () => {
-      bg.init()
+      bg.init();
       expect(chrome.runtime.onConnect.addListener).to.be.called;
     });
 
     it("should call chrome.runtime.onInstalled", () => {
-      bg.init()
+      bg.init();
       expect(chrome.runtime.onInstalled.addListener).to.be.called;
     });
   });

--- a/test/label_view.js
+++ b/test/label_view.js
@@ -1,11 +1,16 @@
 import chai from 'chai';
 import sinon from 'sinon';
-//import chrome from 'sinon-chrome';
 import sinonChai from 'sinon-chai'
 import { assert, expect } from 'chai';
 chai.use(sinonChai);
 
 import LabelView from '../src/label_view.js';
+
+const mockLogger = {
+  info: () => {},
+  debug: () => {},
+  error: () => {},
+}
 
 const mockPort = {
   postMessage: sinon.spy(),
@@ -16,7 +21,7 @@ const mockPort = {
 
 const mockChrome = {
   runtime: {
-    connect: () => mockPort
+    connect: (extensionId, connectInfo) => mockPort
   }
 }
 
@@ -57,7 +62,8 @@ describe("Label View", () => {
     // Reset state before each test run
     sandbox = sinon.createSandbox();
     global.chrome = mockChrome;
-    lv = new LabelView()
+    lv = new LabelView();
+    lv.log = mockLogger;
   });
 
   afterEach(() => {

--- a/test/label_view.js
+++ b/test/label_view.js
@@ -1,16 +1,16 @@
-import chai from 'chai';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai'
-import { assert, expect } from 'chai';
+import chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { assert, expect } from "chai";
 chai.use(sinonChai);
 
-import LabelView from '../src/label_view.js';
+import LabelView from "../src/label_view.js";
 
 const mockLogger = {
   info: () => {},
   debug: () => {},
-  error: () => {},
-}
+  error: () => {}
+};
 
 const mockPort = {
   postMessage: sinon.spy(),
@@ -23,36 +23,36 @@ const mockChrome = {
   runtime: {
     connect: (extensionId, connectInfo) => mockPort
   }
-}
+};
 
 /**
  * DOM node creation helper
  * Makes nodes with id='test-nodes' and adds the contents
  * in `tagString` as children.
  */
-const createDomNodes = (tagString) => {
-  const testNodes = document.createElement('div')
-  testNodes.setAttribute('id', 'test-nodes')
-  document.body.appendChild(testNodes)
+const createDomNodes = tagString => {
+  const testNodes = document.createElement("div");
+  testNodes.setAttribute("id", "test-nodes");
+  document.body.appendChild(testNodes);
 
   // Make the parent of the first div in the document becomes the context node
   const range = document.createRange();
   range.selectNode(testNodes);
   var documentFragment = range.createContextualFragment(tagString);
-  document.getElementById('test-nodes').appendChild(documentFragment);
-  return documentFragment
-}
+  document.getElementById("test-nodes").appendChild(documentFragment);
+  return documentFragment;
+};
 
 /**
  * DOM node cleanup helper.
  * Removes elements with id='test-nodes'
  */
 const cleanupTestNodes = () => {
-  var elem = document.getElementById('test-nodes');
-  if(elem){
+  var elem = document.getElementById("test-nodes");
+  if (elem) {
     elem.parentNode.removeChild(elem);
   }
-}
+};
 
 describe("Label View", () => {
   let lv;
@@ -79,11 +79,15 @@ describe("Label View", () => {
           <div id="testId" class="preview">
             <button class="historybox"></button>
           </div>
-        `)
-        lv.setHistory('testId', true)
-        const hbox = document.querySelector('#testId .historybox')
-        const hClass = hbox.getAttribute('class').split(' ')
-        expect(hClass).to.include.all.members(['follow-unfollow', 'historybox', 'following'])
+        `);
+        lv.setHistory("testId", true);
+        const hbox = document.querySelector("#testId .historybox");
+        const hClass = hbox.getAttribute("class").split(" ");
+        expect(hClass).to.include.all.members([
+          "follow-unfollow",
+          "historybox",
+          "following"
+        ]);
       });
     });
 
@@ -93,20 +97,20 @@ describe("Label View", () => {
           <div id="testId" class="preview">
             <button class="historybox"></button>
           </div>
-        `)
-        lv.setHistory('testId', false)
-        const hbox = document.querySelector('#testId .historybox')
-        expect(hbox.getAttribute('class')).to.not.include('following')
-        expect(hbox.getAttribute('class')).to.include('follow-unfollow')
-        expect(hbox.getAttribute('class')).to.include('historybox')
+        `);
+        lv.setHistory("testId", false);
+        const hbox = document.querySelector("#testId .historybox");
+        expect(hbox.getAttribute("class")).to.not.include("following");
+        expect(hbox.getAttribute("class")).to.include("follow-unfollow");
+        expect(hbox.getAttribute("class")).to.include("historybox");
       });
     });
   });
 
   describe("setPreviewed()", () => {
     it("should postMessage with setTrue:id", () => {
-      lv.setPreviewed(1)
-      expect(mockPort.postMessage).to.be.calledWith({setTrue: 1});
+      lv.setPreviewed(1);
+      expect(mockPort.postMessage).to.be.calledWith({ setTrue: 1 });
     });
   });
 
@@ -116,14 +120,16 @@ describe("Label View", () => {
         <div id="boxClickedParent">
           <div id="boxClickedChild">boxClicked() test</div>
         </div>
-      `)
+      `);
 
       const mockEvent = {
-        target: document.getElementById('boxClickedChild')
-      }
+        target: document.getElementById("boxClickedChild")
+      };
 
-      lv.boxClicked(mockEvent)
-      expect(mockPort.postMessage).to.be.calledWith({toggle: 'boxClickedParent'});
+      lv.boxClicked(mockEvent);
+      expect(mockPort.postMessage).to.be.calledWith({
+        toggle: "boxClickedParent"
+      });
     });
   });
 
@@ -133,15 +139,15 @@ describe("Label View", () => {
         <div id="previewClickedParent">
           <div id="previewClickedChild">previewClicked() test</div>
         </div>
-      `)
+      `);
 
       const mockEvent = {
-        target: document.getElementById('previewClickedChild')
-      }
+        target: document.getElementById("previewClickedChild")
+      };
 
-      sandbox.stub(lv, 'setPreviewed')
-      lv.previewClicked(mockEvent)
-      expect(lv.setPreviewed).to.be.calledWith('previewClickedParent');
+      sandbox.stub(lv, "setPreviewed");
+      lv.previewClicked(mockEvent);
+      expect(lv.setPreviewed).to.be.calledWith("previewClickedParent");
     });
   });
 
@@ -154,14 +160,14 @@ describe("Label View", () => {
             <div class="this-should-disappear"></div>
           </div>
         </div>
-      `)
+      `);
 
       const mockEvent = {
-        target: document.getElementById('fillFrameEventTarget')
-      }
+        target: document.getElementById("fillFrameEventTarget")
+      };
 
       lv.fillFrame(mockEvent);
-      const foundElems = document.querySelectorAll('.this-should-disappear')
+      const foundElems = document.querySelectorAll(".this-should-disappear");
       expect(foundElems.length).to.equal(0);
     });
 
@@ -173,14 +179,14 @@ describe("Label View", () => {
               <div id="fillFrameEventTarget"></div>
               <div id="type-fillFrameTest1" class="preview-frame"></div>
             </div>
-          `)
+          `);
 
           const mockEvent = {
-            target: document.getElementById('fillFrameEventTarget')
-          }
+            target: document.getElementById("fillFrameEventTarget")
+          };
 
           lv.previewOpen = true;
-          lv.previewId = 'fillFrameTest1';
+          lv.previewId = "fillFrameTest1";
           lv.fillFrame(mockEvent);
           expect(lv.previewOpen).to.be.false;
         });
@@ -193,14 +199,14 @@ describe("Label View", () => {
               <div id="fillFrameEventTarget"></div>
               <div id="type-fillFrameTest1" class="preview-frame"></div>
             </div>
-          `)
+          `);
 
           const mockEvent = {
-            target: document.getElementById('fillFrameEventTarget')
-          }
+            target: document.getElementById("fillFrameEventTarget")
+          };
 
           lv.previewOpen = true;
-          lv.previewId = 'doesnt-match-fillFrameTest1';
+          lv.previewId = "doesnt-match-fillFrameTest1";
           lv.fillFrame(mockEvent);
           expect(lv.previewOpen).to.be.true;
         });
@@ -213,16 +219,16 @@ describe("Label View", () => {
             <div id="type-fillFrameTest1" class="preview-frame"></div>
             <div class="historybox"></div>
           </div>
-        `)
+        `);
 
         const mockEvent = {
-          target: document.getElementById('fillFrameEventTarget')
-        }
+          target: document.getElementById("fillFrameEventTarget")
+        };
 
         lv.previewOpen = true;
-        lv.previewId = 'fillFrameTest1';
+        lv.previewId = "fillFrameTest1";
         lv.fillFrame(mockEvent);
-        const foundIframe = document.querySelector('#fillFrameTest1 iframe')
+        const foundIframe = document.querySelector("#fillFrameTest1 iframe");
         expect(foundIframe).to.be.null;
       });
     });
@@ -235,16 +241,16 @@ describe("Label View", () => {
             <div id="type-fillFrameTest1" class="preview-frame"></div>
             <div class="historybox"></div>
           </div>
-        `)
+        `);
 
         const mockEvent = {
-          target: document.getElementById('fillFrameEventTarget')
-        }
+          target: document.getElementById("fillFrameEventTarget")
+        };
 
         lv.previewOpen = false;
         lv.fillFrame(mockEvent);
         expect(lv.previewOpen).to.be.true;
-        expect(lv.previewId).to.equal('fillFrameTest1');
+        expect(lv.previewId).to.equal("fillFrameTest1");
       });
 
       describe("when it creates an iframe", () => {
@@ -255,20 +261,22 @@ describe("Label View", () => {
               <div id="type-fillFrameTest1" class="preview-frame"></div>
               <div class="historybox"></div>
             </div>
-          `)
+          `);
 
           const mockEvent = {
-            target: document.getElementById('fillFrameEventTarget')
-          }
+            target: document.getElementById("fillFrameEventTarget")
+          };
 
           lv.previewOpen = false;
           lv.fillFrame(mockEvent);
-          const foundIframe = document.querySelectorAll('.preview-frame iframe')
+          const foundIframe = document.querySelectorAll(
+            ".preview-frame iframe"
+          );
           expect(foundIframe.length).to.equal(1);
 
           it("and have type=id in the URL", () => {
             expect(true).to.be.true;
-          })
+          });
         });
 
         it("the iframe should have type=id in the URL", () => {
@@ -278,16 +286,16 @@ describe("Label View", () => {
               <div id="type-fillFrameTest1" class="preview-frame"></div>
               <div class="historybox"></div>
             </div>
-          `)
+          `);
 
           const mockEvent = {
-            target: document.getElementById('fillFrameEventTarget')
-          }
+            target: document.getElementById("fillFrameEventTarget")
+          };
 
           lv.previewOpen = false;
           lv.fillFrame(mockEvent);
-          const foundIframe = document.querySelector('.preview-frame iframe')
-          const url = foundIframe.getAttribute('src')
+          const foundIframe = document.querySelector(".preview-frame iframe");
+          const url = foundIframe.getAttribute("src");
           expect(url).to.contain("type=fillFrameTest1");
         });
       });
@@ -297,43 +305,43 @@ describe("Label View", () => {
   describe("generatePreview()", () => {
     it("should return a parent with properties", () => {
       // Todo: when jQuery is removed, change this to `const elem`
-      const $elem = lv.generatePreview('testId', 'testIdType')
-      const elem = $elem.get(0)
-      expect(elem.getAttribute('class')).to.equal('preview')
-      expect(elem.getAttribute('id')).to.equal('testId')
+      const $elem = lv.generatePreview("testId", "testIdType");
+      const elem = $elem.get(0);
+      expect(elem.getAttribute("class")).to.equal("preview");
+      expect(elem.getAttribute("id")).to.equal("testId");
     });
 
     it("should add a preview elem with properties", () => {
       // Todo: when jQuery is removed, change this to `const elem`
-      const $elem = lv.generatePreview('testId', 'testIdType')
-      const elem = $elem.get(0)
-      const preview = elem.querySelector('.preview-frame')
-      expect(preview).to.be.ok
-      expect(preview.getAttribute('id')).to.equal('testIdType-testId')
+      const $elem = lv.generatePreview("testId", "testIdType");
+      const elem = $elem.get(0);
+      const preview = elem.querySelector(".preview-frame");
+      expect(preview).to.be.ok;
+      expect(preview.getAttribute("id")).to.equal("testIdType-testId");
     });
 
     it("should add a button elem with properties", () => {
       // Todo: when jQuery is removed, change this to `const elem`
-      const $elem = lv.generatePreview('testId', 'testIdType')
-      const elem = $elem.get(0)
-      const btn = elem.querySelector('.open-iframe')
-      expect(btn).to.be.ok
-      expect(btn.getAttribute('title')).to.equal('load preview player')
-      expect(btn.getAttribute('class')).to.contain('follow-unfollow')
-      expect(btn.getAttribute('class')).to.contain('open-iframe')
+      const $elem = lv.generatePreview("testId", "testIdType");
+      const elem = $elem.get(0);
+      const btn = elem.querySelector(".open-iframe");
+      expect(btn).to.be.ok;
+      expect(btn.getAttribute("title")).to.equal("load preview player");
+      expect(btn.getAttribute("class")).to.contain("follow-unfollow");
+      expect(btn.getAttribute("class")).to.contain("open-iframe");
     });
 
     it("should add a checkbox elem with properties", () => {
       // Todo: when jQuery is removed, change this to `const elem`
-      const $elem = lv.generatePreview('testId', 'testIdType')
-      const elem = $elem.get(0)
-      const btn = elem.querySelector('.historybox')
-      expect(btn).to.be.ok
-      expect(btn.getAttribute('title')).to.contain('preview history')
-      expect(btn.getAttribute('class')).to.contain('follow-unfollow')
-      expect(btn.getAttribute('class')).to.contain('historybox')
+      const $elem = lv.generatePreview("testId", "testIdType");
+      const elem = $elem.get(0);
+      const btn = elem.querySelector(".historybox");
+      expect(btn).to.be.ok;
+      expect(btn.getAttribute("title")).to.contain("preview history");
+      expect(btn.getAttribute("class")).to.contain("follow-unfollow");
+      expect(btn.getAttribute("class")).to.contain("historybox");
     });
-  })
+  });
 
   describe("renderDom()", () => {
     it("should add preview panes to each .music-grid-item[data-item-id]", () => {
@@ -342,14 +350,14 @@ describe("Label View", () => {
           <li id="rdt1" class="music-grid-item" data-item-id="testIdType1-testId1"></li>
           <li id="rdt2" class="music-grid-item" data-item-id="testIdType2-testId2"></li>
         </ul>
-      `)
-      sandbox.stub(lv, 'generatePreview').callThrough()
-      lv.renderDom()
-      const gridItems = document.querySelectorAll('.music-grid-item')
-      expect(gridItems[0].querySelector('.preview')).to.be.ok
-      expect(gridItems[1].querySelector('.preview')).to.be.ok
-      expect(lv.generatePreview).to.be.calledWith('testId1', 'testIdType1');
-      expect(lv.generatePreview).to.be.calledWith('testId2', 'testIdType2');
+      `);
+      sandbox.stub(lv, "generatePreview").callThrough();
+      lv.renderDom();
+      const gridItems = document.querySelectorAll(".music-grid-item");
+      expect(gridItems[0].querySelector(".preview")).to.be.ok;
+      expect(gridItems[1].querySelector(".preview")).to.be.ok;
+      expect(lv.generatePreview).to.be.calledWith("testId1", "testIdType1");
+      expect(lv.generatePreview).to.be.calledWith("testId2", "testIdType2");
     });
 
     it("should call postMessage for each .music-grid-item[data-item-id]", () => {
@@ -358,10 +366,10 @@ describe("Label View", () => {
           <li id="rdt1" class="music-grid-item" data-item-id="testIdType1-testId1"></li>
           <li id="rdt2" class="music-grid-item" data-item-id="testIdType2-testId2"></li>
         </ul>
-      `)
-      lv.renderDom()
-      expect(mockPort.postMessage).to.be.calledWith({query: 'testId1'});
-      expect(mockPort.postMessage).to.be.calledWith({query: 'testId2'});
+      `);
+      lv.renderDom();
+      expect(mockPort.postMessage).to.be.calledWith({ query: "testId1" });
+      expect(mockPort.postMessage).to.be.calledWith({ query: "testId2" });
     });
 
     it("should add preview panes to each .music-grid-item[data-tralbumid]", () => {
@@ -370,14 +378,14 @@ describe("Label View", () => {
           <li id="rdt1" class="music-grid-item" data-tralbumid="tId1" data-tralbumtype="a"></li>
           <li id="rdt2" class="music-grid-item" data-tralbumid="tId2" data-tralbumtype="a"></li>
         </ul>
-      `)
-      sandbox.stub(lv, 'generatePreview').callThrough()
-      lv.renderDom()
-      const gridItems = document.querySelectorAll('.music-grid-item')
-      expect(gridItems[0].querySelector('.preview')).to.be.ok
-      expect(gridItems[1].querySelector('.preview')).to.be.ok
-      expect(lv.generatePreview).to.be.calledWith('tId1', 'album');
-      expect(lv.generatePreview).to.be.calledWith('tId2', 'album');
+      `);
+      sandbox.stub(lv, "generatePreview").callThrough();
+      lv.renderDom();
+      const gridItems = document.querySelectorAll(".music-grid-item");
+      expect(gridItems[0].querySelector(".preview")).to.be.ok;
+      expect(gridItems[1].querySelector(".preview")).to.be.ok;
+      expect(lv.generatePreview).to.be.calledWith("tId1", "album");
+      expect(lv.generatePreview).to.be.calledWith("tId2", "album");
     });
 
     it("should call postMessage for each .music-grid-item[data-tralbumid]", () => {
@@ -386,34 +394,34 @@ describe("Label View", () => {
           <li id="rdt1" class="music-grid-item" data-tralbumid="tId1" data-tralbumtype="a"></li>
           <li id="rdt2" class="music-grid-item" data-tralbumid="tId2" data-tralbumtype="a"></li>
         </ul>
-      `)
-      lv.renderDom()
-      expect(mockPort.postMessage).to.be.calledWith({query: 'testId1'});
-      expect(mockPort.postMessage).to.be.calledWith({query: 'testId2'});
+      `);
+      lv.renderDom();
+      expect(mockPort.postMessage).to.be.calledWith({ query: "testId1" });
+      expect(mockPort.postMessage).to.be.calledWith({ query: "testId2" });
     });
 
     describe("when data-blob has an item_id in urlParams", () => {
       it("should call setPreviewed", () => {
-        const querystr = '{"lo_querystr":"?item_id=testId&item_type="}'
+        const querystr = '{"lo_querystr":"?item_id=testId&item_type="}';
         createDomNodes(`
           <div id="pagedata" data-blob='${querystr}'>
           </div>
-        `)
-        sandbox.stub(lv, 'setPreviewed')
-        lv.renderDom()
-        expect(lv.setPreviewed).to.be.calledWith('testId');
+        `);
+        sandbox.stub(lv, "setPreviewed");
+        lv.renderDom();
+        expect(lv.setPreviewed).to.be.calledWith("testId");
       });
     });
 
     describe("when data-blob does not have an item_id in urlParams", () => {
       it("should not call setPreviewed", () => {
-        const querystr = '{"lo_querystr":"?item_id=&item_type="}'
+        const querystr = '{"lo_querystr":"?item_id=&item_type="}';
         createDomNodes(`
           <div id="pagedata" data-blob='${querystr}'>
           </div>
-        `)
-        sandbox.stub(lv, 'setPreviewed')
-        lv.renderDom()
+        `);
+        sandbox.stub(lv, "setPreviewed");
+        lv.renderDom();
         expect(lv.setPreviewed).to.not.be.called;
       });
     });

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,0 +1,105 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai'
+import { assert, expect } from 'chai';
+chai.use(sinonChai);
+
+import * as winston from "winston";
+import Logger from '../src/logger.js';
+
+describe("Logger", () => {
+  it("should instantiate a logger", () => {
+    const log = new Logger();
+    expect(log.constructor.name).to.equal('DerivedLogger')
+  });
+
+  it("should have a custom Console transport", () => {
+    const log = new Logger();
+    expect(log.transports[0].constructor.name).to.equal('CustomConsole')
+  });
+
+  describe('CustomConsole', () => {
+    it('should have max listeners set', () => {
+      const log = new Logger();
+      const transporter = log.transports[0]
+      expect(transporter._maxListeners).to.equal(30)
+    })
+
+    it('should have an overridden log method', () => {
+      const log = new Logger();
+      const transporter = log.transports[0]
+      expect(typeof transporter.log).to.equal('function')
+    })
+  });
+
+  describe('Log Level', function () {
+    describe('when level is debug', () => {
+      let consoleSpy;
+
+      beforeEach(() => {
+        // This overrides console.log locally too. If you need to
+        // debug statements here, switch to console.warn.
+        consoleSpy = sinon.stub(console, 'log');
+      });
+
+      afterEach(() => {
+        consoleSpy.restore();
+      })
+
+      it('should print error statements', () => {
+        const log = new Logger();
+        const transporter = log.transports[0]
+
+        log.error('test error')
+
+        const args = consoleSpy.getCall(-1).args
+        expect(args).to.include('test error');
+        expect(args).to.include(`color: ${transporter.levelColors.ERROR};`);
+      });
+
+      it('should print debug statements', () => {
+        const log = new Logger();
+        const transporter = log.transports[0]
+
+        log.debug('test debug')
+
+        const args = consoleSpy.getCall(-1).args
+        expect(args).to.include('test debug');
+        expect(args).to.include(`color: ${transporter.levelColors.DEBUG};`);
+      });
+    });
+    describe('when level is production', () => {
+      let consoleSpy;
+
+      beforeEach(() => {
+        // This overrides console.log locally too. If you need to
+        // debug statements here, switch to console.warn.
+        consoleSpy = sinon.stub(console, 'log');
+      });
+
+      afterEach(() => {
+        consoleSpy.restore();
+      })
+
+      it('should print error statements', () => {
+        const log = new Logger('error');
+        const transporter = log.transports[0]
+
+        log.error('test error')
+
+        const args = consoleSpy.getCall(-1).args
+        expect(args).to.include('test error');
+        expect(args).to.include(`color: ${transporter.levelColors.ERROR};`);
+      });
+
+      it('should NOT print debug statements', () => {
+        const log = new Logger('error');
+        const transporter = log.transports[0]
+
+        log.debug('test debug')
+
+        expect(consoleSpy).to.not.be.called;
+      });
+    });
+  });
+});

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,102 +1,102 @@
-import chai from 'chai';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai'
-import { assert, expect } from 'chai';
+import chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { assert, expect } from "chai";
 chai.use(sinonChai);
 
 import * as winston from "winston";
-import Logger from '../src/logger.js';
+import Logger from "../src/logger.js";
 
 describe("Logger", () => {
   it("should instantiate a logger", () => {
     const log = new Logger();
-    expect(log.constructor.name).to.equal('DerivedLogger')
+    expect(log.constructor.name).to.equal("DerivedLogger");
   });
 
   it("should have a custom Console transport", () => {
     const log = new Logger();
-    expect(log.transports[0].constructor.name).to.equal('CustomConsole')
+    expect(log.transports[0].constructor.name).to.equal("CustomConsole");
   });
 
-  describe('CustomConsole', () => {
-    it('should have max listeners set', () => {
+  describe("CustomConsole", () => {
+    it("should have max listeners set", () => {
       const log = new Logger();
-      const transporter = log.transports[0]
-      expect(transporter._maxListeners).to.equal(30)
-    })
+      const transporter = log.transports[0];
+      expect(transporter._maxListeners).to.equal(30);
+    });
 
-    it('should have an overridden log method', () => {
+    it("should have an overridden log method", () => {
       const log = new Logger();
-      const transporter = log.transports[0]
-      expect(typeof transporter.log).to.equal('function')
-    })
+      const transporter = log.transports[0];
+      expect(typeof transporter.log).to.equal("function");
+    });
   });
 
-  describe('Log Level', function () {
-    describe('when level is debug', () => {
+  describe("Log Level", function() {
+    describe("when level is debug", () => {
       let consoleSpy;
 
       beforeEach(() => {
         // This overrides console.log locally too. If you need to
         // debug statements here, switch to console.warn.
-        consoleSpy = sinon.stub(console, 'log');
+        consoleSpy = sinon.stub(console, "log");
       });
 
       afterEach(() => {
         consoleSpy.restore();
-      })
+      });
 
-      it('should print error statements', () => {
+      it("should print error statements", () => {
         const log = new Logger();
-        const transporter = log.transports[0]
+        const transporter = log.transports[0];
 
-        log.error('test error')
+        log.error("test error");
 
-        const args = consoleSpy.getCall(-1).args
-        expect(args).to.include('test error');
+        const args = consoleSpy.getCall(-1).args;
+        expect(args).to.include("test error");
         expect(args).to.include(`color: ${transporter.levelColors.ERROR};`);
       });
 
-      it('should print debug statements', () => {
+      it("should print debug statements", () => {
         const log = new Logger();
-        const transporter = log.transports[0]
+        const transporter = log.transports[0];
 
-        log.debug('test debug')
+        log.debug("test debug");
 
-        const args = consoleSpy.getCall(-1).args
-        expect(args).to.include('test debug');
+        const args = consoleSpy.getCall(-1).args;
+        expect(args).to.include("test debug");
         expect(args).to.include(`color: ${transporter.levelColors.DEBUG};`);
       });
     });
-    describe('when level is production', () => {
+    describe("when level is production", () => {
       let consoleSpy;
 
       beforeEach(() => {
         // This overrides console.log locally too. If you need to
         // debug statements here, switch to console.warn.
-        consoleSpy = sinon.stub(console, 'log');
+        consoleSpy = sinon.stub(console, "log");
       });
 
       afterEach(() => {
         consoleSpy.restore();
-      })
+      });
 
-      it('should print error statements', () => {
-        const log = new Logger('error');
-        const transporter = log.transports[0]
+      it("should print error statements", () => {
+        const log = new Logger("error");
+        const transporter = log.transports[0];
 
-        log.error('test error')
+        log.error("test error");
 
-        const args = consoleSpy.getCall(-1).args
-        expect(args).to.include('test error');
+        const args = consoleSpy.getCall(-1).args;
+        expect(args).to.include("test error");
         expect(args).to.include(`color: ${transporter.levelColors.ERROR};`);
       });
 
-      it('should NOT print debug statements', () => {
-        const log = new Logger('error');
-        const transporter = log.transports[0]
+      it("should NOT print debug statements", () => {
+        const log = new Logger("error");
+        const transporter = log.transports[0];
 
-        log.debug('test debug')
+        log.debug("test debug");
 
         expect(consoleSpy).to.not.be.called;
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,19 @@ module.exports = {
         jQuery: "jquery"
     })
   ],
-  node: { fs: 'empty' },
+
+  // Since this is a browser app, explicitly disable NodeJS's `fs` methods.
+  // This prevents transpilation errors for libraries like Winston that
+  // offer support for server-side features.
+  node: {
+    fs: 'empty'
+  },
+
+  // Default to production, override with --mode=development.
+  // See https://webpack.js.org/configuration/mode/ for the features included
+  // with either build.
   mode: 'production',
+
   entry: {
     content: './src/label_view.js',
     background: './src/background.js',
@@ -18,11 +29,9 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
   },
-  optimization: {
-    // We no not want to minimize our code.
-    minimize: false
-  },
-  devtool: "inline-source-map", //fixes "eval" error in chrome
+
+  // Fixes the "eval" error in Chrome
+  devtool: "inline-source-map",
 
   // Run with --watch to enable these options
   watchOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,8 @@ module.exports = {
         jQuery: "jquery"
     })
   ],
+  node: { fs: 'empty' },
+  mode: 'production',
   entry: {
     content: './src/label_view.js',
     background: './src/background.js',
@@ -21,4 +23,9 @@ module.exports = {
     minimize: false
   },
   devtool: "inline-source-map", //fixes "eval" error in chrome
+
+  // Run with --watch to enable these options
+  watchOptions: {
+    ignored: /node_modules/
+  }
 };


### PR DESCRIPTION
Resolves https://github.com/sabjorn/BandcampEnhancementSuite/issues/36

Adds a logger class that provides environment-controlled output: in production it only logs errors, and in development it logs warnings and info statements too.

Notable changes:

- ESLint rules have been adjusted to flag any trailing `console` statements. If a statement is really needed, it can be skipped with the `// eslint-disable-next-line no-console` comment.
- To make linting easier, an `npm run lint:fix` script was added
- The NPM `build` commands have been stacked for auto-rebuild dev workflow, and production-targeted default builds
- The `chrome.runtime.connect` throws when testing in visible Chrome - to prevent this, it has been wrapped in a try/catch. I wasn't able to figure out how to mock the `chrome` global any better.
- The `./test/` directory is now included in the lint script, so there are lots of small fixes... apologies.