### PR TITLE
Remove jQuery dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3939,11 +3939,6 @@
       "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Chrome extension adding extra features to the Bandcamp experience.",
   "dependencies": {
     "idb": "^5.0.3",
-    "jquery": "^3.5.0",
     "winston": "^3.3.2"
   },
   "devDependencies": {

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,4 +1,3 @@
-import $ from "jquery";
 import Logger from "./logger";
 
 export default class LabelView {

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -31,18 +31,23 @@ export default class LabelView {
         this.setPreviewed(key);
       }
     });
+  }
 
-    $(document).ready(() => {
-      this.log.info("Rendering DOM...");
-      this.renderDom();
-    });
+  init() {
+    this.log.info("Rendering BES...");
+    this.renderDom();
   }
 
   setHistory(id, state) {
-    let historybox = $(`div.preview[id='${id}']`).find("button.historybox");
-    if (state)
-      $(historybox).attr("class", "follow-unfollow historybox following");
-    else $(historybox).attr("class", "follow-unfollow historybox");
+    // CSS.escape() is required for integer-only CSS IDs
+    const historybox = document.querySelector(`#${CSS.escape(id)} .historybox`);
+    historybox.classList.add("follow-unfollow");
+
+    if (state) {
+      historybox.classList.add("following");
+    } else {
+      historybox.classList.remove("following");
+    }
   }
 
   setPreviewed(id) {
@@ -50,28 +55,28 @@ export default class LabelView {
   }
 
   boxClicked(event) {
-    const id = $(event.target)
-      .parents("div")
-      .attr("id");
+    const id = event.target.parentElement.getAttribute("id");
 
     this.port.postMessage({ toggle: id });
   }
 
   previewClicked(event) {
-    const id = $(event.target)
-      .parents("div")
-      .attr("id");
+    const id = event.target.parentElement.getAttribute("id");
 
     this.setPreviewed(id);
   }
 
   fillFrame(event) {
-    $(".preview-frame").html(""); // clear all iframes
+    document.querySelectorAll(".preview-frame").forEach(item => {
+      while (item.firstChild) {
+        item.removeChild(item.firstChild);
+      }
+    });
 
-    let $preview = $(event.target)
-      .parents(".music-grid-item")
-      .find(".preview-frame");
-    const idAndType = $preview.attr("id");
+    let preview = event.target
+      .closest(".music-grid-item")
+      .querySelector(".preview-frame");
+    const idAndType = preview.getAttribute("id");
     const id = idAndType.split("-")[1];
     const idType = idAndType.split("-")[0];
 
@@ -90,89 +95,100 @@ export default class LabelView {
 
       const iframe_style =
         "margin: 6px 0px 0px 0px; border: 0; width: 150%; height: 300px; position:relative; z-index:1;";
-      const iframe_val = `<iframe style="${iframe_style}" src="${url}" seamless></iframe>`;
-      $preview.html(iframe_val);
+
+      const iframe = document.createElement("iframe");
+      iframe.setAttribute("style", iframe_style);
+      iframe.setAttribute("src", url);
+      iframe.setAttribute("seamless", "");
+      preview.appendChild(iframe);
     }
   }
 
   generatePreview(id, idType) {
-    let $button = $("<button>")
-      .attr("title", "load preview player")
-      .attr("type", "button")
-      .attr("class", "follow-unfollow open-iframe")
-      .attr("style", "width: 90%");
+    let button = document.createElement("button");
+    button.setAttribute("title", "load preview player");
+    button.setAttribute("type", "button");
+    button.setAttribute("class", "follow-unfollow open-iframe");
+    button.setAttribute("style", "width: 90%");
+    button.append("Preview");
 
-    let $preview = $("<div>").html("Preview");
-    $button.append($preview);
+    let checkbox = document.createElement("button");
+    checkbox.setAttribute("title", "preview history (click to toggle)");
+    checkbox.setAttribute(
+      "style",
+      "margin: 0px 0px 0px 5px; width: 28px; height: 28px; position: absolute;"
+    );
+    checkbox.setAttribute("class", "follow-unfollow historybox");
 
-    let $checkbox = $("<button>")
-      .attr("title", "preview history (click to toggle)")
-      .attr(
-        "style",
-        "margin: 0px 0px 0px 5px; width: 28px; height: 28px; position: absolute;"
-      )
-      .attr("class", "follow-unfollow historybox");
+    let preview = document.createElement("div");
+    preview.setAttribute("class", "preview-frame");
+    preview.setAttribute("id", `${idType}-${id}`);
 
-    $preview = $("<div>")
-      .attr("class", "preview-frame")
-      .attr("id", `${idType}-${id}`);
+    let parent = document.createElement("div");
+    parent.setAttribute("id", id);
+    parent.setAttribute("class", "preview");
+    parent.appendChild(button);
+    parent.appendChild(checkbox);
+    parent.appendChild(preview);
 
-    let $parent = $("<div>")
-      .attr("id", id)
-      .attr("class", "preview")
-      .append($button)
-      .append($checkbox)
-      .append($preview);
-
-    return $parent;
+    return parent;
   }
 
   renderDom() {
     // iterate over page to get album IDs and append buttons with value
-    $("li.music-grid-item[data-item-id]").each((index, item) => {
-      const idAndType = $(item)
-        .closest("li")
-        .attr("data-item-id");
-      const id = idAndType.split("-")[1];
-      const idType = idAndType.split("-")[0];
-      let $preview = this.generatePreview(id, idType);
-      $(item).append($preview);
-
-      this.port.postMessage({ query: id });
-    });
-
-    $('li.music-grid-item[data-tralbumid][data-tralbumtype="a"]').each(
-      (index, item) => {
-        const id = $(item).attr("data-tralbumid");
-        let $preview = this.generatePreview(id, "album");
-        $(item).append($preview);
+    document
+      .querySelectorAll("li.music-grid-item[data-item-id]")
+      .forEach(item => {
+        const idAndType = item.dataset.itemId;
+        const id = idAndType.split("-")[1];
+        const idType = idAndType.split("-")[0];
+        let $preview = this.generatePreview(id, idType);
+        item.appendChild($preview);
 
         this.port.postMessage({ query: id });
-      }
-    );
-
-    $("#pagedata")
-      .first()
-      .each((index, item) => {
-        const datablob = JSON.parse($(item).attr("data-blob"));
-        const urlParams = new URLSearchParams(datablob.lo_querystr);
-        const id = urlParams.get("item_id");
-        if (id) {
-          this.setPreviewed(id);
-        }
       });
 
-    $(".open-iframe").on("click", event => {
-      this.fillFrame(event);
-      this.previewClicked(event);
-    });
+    document
+      .querySelectorAll(
+        'li.music-grid-item[data-tralbumid][data-tralbumtype="a"]'
+      )
+      .forEach(item => {
+        const id = item.dataset.tralbumid;
+        let preview = this.generatePreview(id, "album");
+        item.appendChild(preview);
 
-    $(".historybox").on("click", event => {
-      this.boxClicked(event);
-    });
+        this.port.postMessage({ query: id });
+      });
+
+    const pagedata = document.querySelector("#pagedata");
+    const datablob = JSON.parse(pagedata.dataset.blob);
+    const urlParams = new URLSearchParams(datablob.lo_querystr);
+    const id = urlParams.get("item_id");
+    if (id) {
+      this.setPreviewed(id);
+    }
+
+    const openFrame = document
+      .querySelectorAll(".open-iframe")
+      .forEach(item => {
+        item.addEventListener("click", event => {
+          this.fillFrame(event);
+          this.previewClicked(event);
+        });
+      });
+
+    const historybox = document
+      .querySelectorAll(".historybox")
+      .forEach(item => {
+        item.addEventListener("click", event => {
+          this.boxClicked(event);
+        });
+      });
   }
 }
 
 window.onload = () => {
-  new LabelView();
+  const lv = new LabelView();
+
+  lv.init();
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,6 @@ const webpack = require('webpack');
 
 module.exports = {
   plugins: [
-    new webpack.ProvidePlugin({
-        $: "jquery",
-        jQuery: "jquery"
-    })
   ],
 
   // Since this is a browser app, explicitly disable NodeJS's `fs` methods.


### PR DESCRIPTION
Resolves #37 

Converts jQuery selector syntax to slightly wordier Javascript. I think Chrome should load this extension after the DOMReady is fired so there is no need to emulate the `$(document).ready()` call, but if this doesn't turn out to be the case then we should investigate the `run_at` manifest config option.

Does the `.follow-unfollow` class actually get used? It kind of looks like it might have been intended to be an event trigger at one point, shared between the checkbox and preview button, but now each of those elements have dedicated click listeners and resulting functions. If `.follow-unfollow` is unused, it could be removed from the code and the tests.