### PR TITLE
add keyboard and mouse control to player on regular album windows

### DIFF
--- a/html/browser_action.html
+++ b/html/browser_action.html
@@ -18,6 +18,29 @@
 
 <div id="mainPopup">
 <h1>Bandcamp Enhancement Suite</h1>
+<h2>Keyboard Shortcuts</h2>
+    <div>
+        <p>On any album page the following keyboard shortcuts are active</p>
+        <ul>
+            <li>
+                <strong>Space Bar</strong> or <strong>"p"</strong> - Play/Pause Player
+            </li>
+            <li>
+                <strong>Right Arrow</strong> - Move Playhead Forward 10s
+            </li>
+            <li>
+                <strong>Left Arrow</strong> - Move Playhead Back 10s
+            </li>
+            <li>
+                <strong>Down Arrow</strong> - Play Next Track
+            </li>
+            <li>
+                <strong>Up Arrow</strong> - Play Previous Track
+            </li>
+        </ul>
+    </div>
+
+<h2>Links</h2>
 <ul>
     <li>
         <a href="https://github.com/sabjorn/BandcampEnhancementSuite" target="_blank">

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import LabelView from "./label_view.js";
 import DownloadHelper from "./download_helper.js";
+import Player from "./player.js";
 
 window.onload = () => {
   const lv = new LabelView();
@@ -9,5 +10,11 @@ window.onload = () => {
   if (checkIsDownloadPage) {
     const dh = new DownloadHelper();
     dh.init();
+  }
+
+  let checkIsPageWithPlayer = document.querySelector("div.inline_player");
+  if (checkIsPageWithPlayer) {
+    const player = new Player();
+    player.init();
   }
 };

--- a/src/player.js
+++ b/src/player.js
@@ -20,7 +20,7 @@ export default class Player {
   }
 
   static keydownCallback(e) {
-    this.log.info("Keydown");
+    this.log.info("Keydown: " + e.key);
     if (e.key == " " || e.key == "p")
     {
       e.preventDefault();

--- a/src/player.js
+++ b/src/player.js
@@ -22,23 +22,32 @@ export default class Player {
   static keydownCallback(e) {
     this.log.info("Keydown");
     if (e.key == " " || e.key == "p")
+    {
+      e.preventDefault();
       document.querySelector("div.playbutton").click();
+    }
 
-    if (e.key == "ArrowUp") document.querySelector("div.prevbutton").click();
+    if (e.key == "ArrowUp"){
+      e.preventDefault();
+      document.querySelector("div.prevbutton").click();
+    }
 
-    if (e.key == "ArrowDown") document.querySelector("div.nextbutton").click();
+    if (e.key == "ArrowDown"){
+      e.preventDefault();
+      document.querySelector("div.nextbutton").click();
+    }
 
     if (e.key == "ArrowRight") {
+      e.preventDefault();
       let audio = document.querySelector("audio");
       audio.currentTime = audio.currentTime + stepSize;
     }
 
     if (e.key == "ArrowLeft") {
+      e.preventDefault();
       let audio = document.querySelector("audio");
       audio.currentTime = audio.currentTime - stepSize;
     }
-
-    if (e.target == document.body) e.preventDefault();
   }
 
   static mousedownCallback(e) {

--- a/src/player.js
+++ b/src/player.js
@@ -1,0 +1,54 @@
+import Logger from "./logger";
+
+const stepSize = 10;
+
+export default class Player {
+  constructor() {
+    this.log = new Logger();
+    this.boundKeydown = Player.keydownCallback.bind(this);
+    this.boundMousedown = Player.mousedownCallback.bind(this);
+  }
+
+  init() {
+    this.log.info("Starting BES Player");
+
+    document.addEventListener("keydown", this.boundKeydown);
+
+    let progressBar = document.querySelector(".progbar");
+    progressBar.style.cursor = "pointer";
+    progressBar.addEventListener("click", this.boundMousedown);
+  }
+
+  static keydownCallback(e) {
+    this.log.info("Keydown");
+    if (e.key == " " || e.key == "p")
+      document.querySelector("div.playbutton").click();
+
+    if (e.key == "ArrowUp") document.querySelector("div.prevbutton").click();
+
+    if (e.key == "ArrowDown") document.querySelector("div.nextbutton").click();
+
+    if (e.key == "ArrowRight") {
+      let audio = document.querySelector("audio");
+      audio.currentTime = audio.currentTime + stepSize;
+    }
+
+    if (e.key == "ArrowLeft") {
+      let audio = document.querySelector("audio");
+      audio.currentTime = audio.currentTime - stepSize;
+    }
+
+    if (e.target == document.body) e.preventDefault();
+  }
+
+  static mousedownCallback(e) {
+    this.log.info("Mousedown");
+    const elementOffset = e.offsetX;
+    const elementWidth = e.path[1].offsetWidth;
+    const scaleDurration = elementOffset / elementWidth;
+
+    let audio = document.querySelector("audio");
+    let audioDuration = audio.duration;
+    audio.currentTime = scaleDurration * audioDuration;
+  }
+}

--- a/src/player.js
+++ b/src/player.js
@@ -21,18 +21,17 @@ export default class Player {
 
   static keydownCallback(e) {
     this.log.info("Keydown: " + e.key);
-    if (e.key == " " || e.key == "p")
-    {
+    if (e.key == " " || e.key == "p") {
       e.preventDefault();
       document.querySelector("div.playbutton").click();
     }
 
-    if (e.key == "ArrowUp"){
+    if (e.key == "ArrowUp") {
       e.preventDefault();
       document.querySelector("div.prevbutton").click();
     }
 
-    if (e.key == "ArrowDown"){
+    if (e.key == "ArrowDown") {
       e.preventDefault();
       document.querySelector("div.nextbutton").click();
     }

--- a/test/player.js
+++ b/test/player.js
@@ -67,10 +67,13 @@ describe("Player", () => {
   });
 
   describe("boundKeydown", () => {
-    const spyElement = { click: sinon.spy() };
-    let event = { key: "" };
+    let spyElement;
+    let event;
 
     beforeEach(() => {
+      event = { key: "", preventDefault: sinon.spy() };
+      spyElement = { click: sinon.spy() };
+
       sinon.stub(document, "querySelector").returns(spyElement);
     });
 
@@ -90,6 +93,7 @@ describe("Player", () => {
 
       expect(document.querySelector).to.be.calledWith("div.playbutton");
       expect(spyElement.click).to.have.been.called;
+      expect(event.preventDefault).to.have.been.called;
     });
 
     it("click prevbutton if 'ArrowUp'", () => {
@@ -98,6 +102,7 @@ describe("Player", () => {
 
       expect(document.querySelector).to.be.calledWith("div.prevbutton");
       expect(spyElement.click).to.have.been.called;
+      expect(event.preventDefault).to.have.been.called;
     });
 
     it("click nextbutton if 'ArrowDown'", () => {
@@ -106,6 +111,7 @@ describe("Player", () => {
 
       expect(document.querySelector).to.be.calledWith("div.nextbutton");
       expect(spyElement.click).to.have.been.called;
+      expect(event.preventDefault).to.have.been.called;
     });
 
     it("jump audio ahead 10s if 'ArrowRight'", () => {
@@ -116,6 +122,7 @@ describe("Player", () => {
 
       expect(document.querySelector).to.be.calledWith("audio");
       expect(spyElement.currentTime).to.be.equal(110);
+      expect(event.preventDefault).to.have.been.called;
     });
 
     it("jump audio back 10s if 'ArrowLeft'", () => {
@@ -126,16 +133,14 @@ describe("Player", () => {
 
       expect(document.querySelector).to.be.calledWith("audio");
       expect(spyElement.currentTime).to.be.equal(90);
+      expect(event.preventDefault).to.have.been.called;
     });
 
-    it("prevent all onpage buttons from being called", () => {
-      let event = {
-        target: document.body,
-        preventDefault: sinon.spy()
-      };
+    it("does not prevent other keys from being called", () => {
+      event.key = "null";
       player.boundKeydown(event);
 
-      expect(event.preventDefault).to.be.called;
+      expect(event.preventDefault).to.have.not.been.called;
     });
   });
 

--- a/test/player.js
+++ b/test/player.js
@@ -1,0 +1,168 @@
+import { createDomNodes, cleanupTestNodes } from "./utils.js";
+import chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { assert, expect } from "chai";
+chai.use(sinonChai);
+
+import Player from "../src/player.js";
+
+describe("Player", () => {
+  let player;
+  let sandbox;
+
+  beforeEach(() => {
+    // Reset state before each test run
+    sandbox = sinon.createSandbox();
+    player = new Player();
+
+    // Prevent Logger output during tests
+    sandbox.stub(player, "log");
+  });
+
+  afterEach(() => {
+    // Preemptive removal of any test-nodes
+    cleanupTestNodes();
+    sandbox.restore();
+  });
+
+  describe("init()", () => {
+    beforeEach(() => {
+      createDomNodes(`
+        <div id="testId" class="progbar"></div>
+      `);
+    });
+
+    it("binds global keydown method", () => {
+      sinon.spy(document, "addEventListener");
+
+      player.init();
+
+      expect(document.addEventListener).to.have.been.calledWith(
+        "keydown",
+        player.boundKeydown
+      );
+    });
+
+    it("initializes and binds progressbar", () => {
+      let progressbar = {
+        style: { cursor: "none" },
+        addEventListener: sinon.spy()
+      };
+      sinon
+        .stub(document, "querySelector")
+        .withArgs(".progbar")
+        .returns(progressbar);
+
+      player.init();
+
+      expect(progressbar.style.cursor).to.be.equal("pointer");
+      expect(progressbar.addEventListener).to.have.been.calledWith(
+        "click",
+        player.boundMousedown
+      );
+
+      document.querySelector.restore();
+    });
+  });
+
+  describe("boundKeydown", () => {
+    const spyElement = { click: sinon.spy() };
+    let event = { key: "" };
+
+    beforeEach(() => {
+      sinon.stub(document, "querySelector").returns(spyElement);
+    });
+
+    afterEach(() => {
+      document.querySelector.restore();
+    });
+
+    it("click play button if space or 'p' pushed", () => {
+      event.key = "p";
+      player.boundKeydown(event);
+
+      expect(document.querySelector).to.be.calledWith("div.playbutton");
+      expect(spyElement.click).to.have.been.called;
+
+      event.key = " ";
+      player.boundKeydown(event);
+
+      expect(document.querySelector).to.be.calledWith("div.playbutton");
+      expect(spyElement.click).to.have.been.called;
+    });
+
+    it("click prevbutton if 'ArrowUp'", () => {
+      event.key = "ArrowUp";
+      player.boundKeydown(event);
+
+      expect(document.querySelector).to.be.calledWith("div.prevbutton");
+      expect(spyElement.click).to.have.been.called;
+    });
+
+    it("click nextbutton if 'ArrowDown'", () => {
+      event.key = "ArrowDown";
+      player.boundKeydown(event);
+
+      expect(document.querySelector).to.be.calledWith("div.nextbutton");
+      expect(spyElement.click).to.have.been.called;
+    });
+
+    it("jump audio ahead 10s if 'ArrowRight'", () => {
+      spyElement.currentTime = 100;
+
+      event.key = "ArrowRight";
+      player.boundKeydown(event);
+
+      expect(document.querySelector).to.be.calledWith("audio");
+      expect(spyElement.currentTime).to.be.equal(110);
+    });
+
+    it("jump audio back 10s if 'ArrowLeft'", () => {
+      spyElement.currentTime = 100;
+
+      event.key = "ArrowLeft";
+      player.boundKeydown(event);
+
+      expect(document.querySelector).to.be.calledWith("audio");
+      expect(spyElement.currentTime).to.be.equal(90);
+    });
+
+    it("prevent all onpage buttons from being called", () => {
+      let event = {
+        target: document.body,
+        preventDefault: sinon.spy()
+      };
+      player.boundKeydown(event);
+
+      expect(event.preventDefault).to.be.called;
+    });
+  });
+
+  describe("boundMousedown", () => {
+    const spyElement = { click: sinon.spy() };
+
+    beforeEach(() => {
+      sinon.stub(document, "querySelector").returns(spyElement);
+    });
+
+    afterEach(() => {
+      document.querySelector.restore();
+    });
+
+    it("positions audio play position based on click", () => {
+      spyElement.duration = 100;
+      spyElement.currentTime = 0;
+
+      let event = {
+        offsetX: 1,
+        path: [{ offsetWidth: 0 }, { offsetWidth: 2 }]
+      };
+
+      player.boundMousedown(event);
+
+      expect(document.querySelector).to.be.calledWith("audio");
+      expect(spyElement.currentTime).to.be.equal(50);
+    });
+  });
+});


### PR DESCRIPTION
keys:
* space and 'p' - play/pause
* up arrow - previous track
* down arrow - next track
* right arrow - skip ahead 10 seconds
* left arrow - skip back 10 seconds

mouse:
* clicking anywhere on the audio playbar now jumps to that position

additional notes:
* some indication to the user of this keymap would be ideal. Was thinking it might work to add a little div by the player that opens when clicking a "?" icon
* it would be neat if this keybinding worked for the preview player. for now it does not.
* all regular keybindings on the page (e.g. space bar to scroll) are disabled.