### PR TITLE
add volume control to album pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,30 @@
+/* player.js Volume Slider */
+input[type="range" i].volume
+{
+     position:absolute;
+     width: 20% !important;
+     height: 8px;
+     left: 94%;
+     top: 35%;
+     cursor: pointer;
+     -webkit-appearance: none;
+     -webkit-transform: rotate(270deg);
+     overflow: hidden; /* needed for boxshadow hack */
+}
+
+input[type="range"].volume:focus
+{
+     border: 0 !imporant;
+     outline: none !important;
+}
+
+input[type="range"].volume::-webkit-slider-thumb
+{
+     -webkit-appearance: none;
+     overflow: visible;
+     width: 20px;
+     height: 12px;
+     background-color: #fff;
+     border: 1px solid #bebebe;
+     box-shadow: -100px 0 0 100px #f6f6f6;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
       ],
       "js": [
         "dist/main.js"
-      ]
+      ],
+      "css": ["css/style.css"]
     }
   ]
 }

--- a/src/player.js
+++ b/src/player.js
@@ -5,8 +5,10 @@ const stepSize = 10;
 export default class Player {
   constructor() {
     this.log = new Logger();
+
     this.boundKeydown = Player.keydownCallback.bind(this);
     this.boundMousedown = Player.mousedownCallback.bind(this);
+    this.boundVolume = Player.volumeSliderCallback.bind(this);
   }
 
   init() {
@@ -17,6 +19,26 @@ export default class Player {
     let progressBar = document.querySelector(".progbar");
     progressBar.style.cursor = "pointer";
     progressBar.addEventListener("click", this.boundMousedown);
+
+    this.addVolumeSlider();
+  }
+
+  addVolumeSlider() {
+    let input = document.createElement("input");
+    input.type = "range";
+    input.classList = "volume thumb progbar_empty";
+    input.min = 0.0;
+    input.max = 1.0;
+    input.step = 0.01;
+    input.title = "volume control";
+
+    let audio = document.querySelector("audio");
+    input.value = audio.volume;
+
+    input.addEventListener("input", this.boundVolume);
+
+    let inlineplayer = document.querySelector("div.inline_player");
+    if (!inlineplayer.classList.contains("hidden")) inlineplayer.append(input);
   }
 
   static keydownCallback(e) {
@@ -58,5 +80,13 @@ export default class Player {
     let audio = document.querySelector("audio");
     let audioDuration = audio.duration;
     audio.currentTime = scaleDurration * audioDuration;
+  }
+
+  static volumeSliderCallback(e) {
+    let volume = e.target.value;
+    let audio = document.querySelector("audio");
+    audio.volume = volume;
+
+    this.log.info("volume:", volume);
   }
 }

--- a/test/player.js
+++ b/test/player.js
@@ -31,6 +31,8 @@ describe("Player", () => {
       createDomNodes(`
         <div id="testId" class="progbar"></div>
       `);
+
+      player.addVolumeSlider = sinon.spy();
     });
 
     it("binds global keydown method", () => {
@@ -63,6 +65,78 @@ describe("Player", () => {
       );
 
       document.querySelector.restore();
+    });
+
+    it("runs addVolumeSlider()", () => {
+      player.init();
+
+      expect(player.addVolumeSlider).to.have.been.called;
+    });
+  });
+
+  describe("addVolumeSlider", () => {
+    let input;
+    let audio;
+    let inlineplayer;
+
+    beforeEach(() => {
+      input = { addEventListener: sinon.spy() };
+
+      audio = {};
+
+      inlineplayer = {
+        classList: { contains: sinon.stub() },
+        append: sinon.spy()
+      };
+
+      sinon.stub(document, "querySelector");
+      document.querySelector.withArgs("audio").returns(audio);
+      document.querySelector
+        .withArgs("div.inline_player")
+        .returns(inlineplayer);
+
+      sinon.stub(document, "createElement").returns(input);
+    });
+    afterEach(() => {
+      document.querySelector.restore();
+      document.createElement.restore();
+    });
+
+    it("creates an input element with specific attributes", () => {
+      audio.volume = 123.45;
+
+      player.addVolumeSlider();
+
+      expect(input.type).is.equal("range");
+      expect(input.min).is.equal(0.0);
+      expect(input.max).is.equal(1.0);
+      expect(input.step).is.equal(0.01);
+      expect(input.value).is.equal(123.45);
+    });
+
+    it("binds boundVolume callback to input element", () => {
+      player.addVolumeSlider();
+
+      expect(input.addEventListener).to.have.been.calledWith(
+        "input",
+        player.boundVolume
+      );
+    });
+
+    it("appends input to document element if that element is not hidden", () => {
+      inlineplayer.classList.contains = sinon.stub().returns(false);
+
+      player.addVolumeSlider();
+
+      expect(inlineplayer.append).to.have.been.calledWith(input);
+    });
+
+    it("does not append input to document element if that element is hidden", () => {
+      inlineplayer.classList.contains = sinon.stub().returns(true);
+
+      player.addVolumeSlider();
+
+      expect(inlineplayer.append).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
There is a volume control for HTML5 audio elements but Bandcamp just doesn't use it. This feature adds a control to the right side of the player on album pages to provide volume control.

The control uses a css file to make the `input` element (which controls the volume) to look as close to the player playbar as possible.

**Note**: one element of the playbar which is currently not replciated is that the "playhead" graphic is slightly larger than the timeline graphic. This has been sacrificed with the `input` element in order to replicate the white/grey effect of aboe/below the "playhead" (which is done as a hack with the `boxshadow` + `overflow: visible`)
