### PR TITLE
add feature to move album page tracklist to directly below player

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,19 @@ On album and track pages the following keyboard controls are supported:
 Click anywhere on the playbar to set the "playhead" of the player.
 
 ### Waveform Display
-Adds a wavform display similar to visualization of Soundcloud. A toggle belo the "play button" on album pages will enable/disable the display.
+Adds a wavform display similar to visualization of Soundcloud. A toggle below the "play button" on album pages will enable/disable the display.
 **Note**: The waveform is processed browserside.
 
 ### Volume Control
 Adds a slider on the right side of the player controls volume.
+
+### Control Relocation
+Moves the forward/back buttons for the player (on album and track pages) to right under the play/pause button.
+
+### Tracklist Relocation
+Moves the tracklist on an album's page directly below the player.
+
+
 
 ### Bundle Purchase Download Button
 Adds a button to help automate the process of download a cart after purchase. Once all music download links are ready this button, when clicked, generate a `.txt` file which can be **pasted** into [terminal](https://en.wikipedia.org/wiki/List_of_terminal_emulators) to automate the downloading process. This `.txt` file uses [cURL](https://en.wikipedia.org/wiki/CURL).

--- a/src/player.js
+++ b/src/player.js
@@ -20,6 +20,8 @@ export default class Player {
     progressBar.style.cursor = "pointer";
     progressBar.addEventListener("click", mousedownCallback);
 
+    Player.movePlaylist();
+
     this.updatePlayerControlInterface();
   }
 
@@ -40,6 +42,15 @@ export default class Player {
     let inlineplayer = document.querySelector("div.inline_player");
     if (!inlineplayer.classList.contains("hidden"))
       inlineplayer.prepend(controls);
+  }
+
+  static movePlaylist() {
+    const playlist = document.querySelector("table#track_table");
+    if(playlist)
+    {
+      const player = document.querySelector("div.inline_player")
+      player.after(playlist);
+    }
   }
 
   static createVolumeSlider() {


### PR DESCRIPTION
Often album pages have a lot of information shoved between the player and the tracklist. This is incredibly inconvenient.

This commit adds a small addition to `player.js` to move the document element to be in the correct place.

implements #62