### PR TITLE
remove 'storage' requirement

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,6 @@
   "permissions": [
     "http://*.bandcamp.com/*",
     "https://*.bandcamp.com/*",
-    "storage",
     "https://t4.bcbits.com/stream/*"
   ],
   "background": {

--- a/src/background/label_view_backend.js
+++ b/src/background/label_view_backend.js
@@ -28,19 +28,6 @@ export default class LabelViewBackend {
       function isEmpty(obj) {
         return Object.keys(obj).length === 0;
       }
-      // upgrade old storage
-      const storeName = "previews";
-      chrome.storage.sync.get(storeName, function(result) {
-        try {
-          if (!isEmpty(result)) {
-            result[storeName].forEach(function(item, index) {
-              LabelViewBackend.setVal(storeName, true, item);
-            });
-          }
-        } catch (e) {
-          this.log.error(e);
-        }
-      });
     });
   }
 

--- a/src/label_view.js
+++ b/src/label_view.js
@@ -23,14 +23,6 @@ export default class LabelView {
         throw e;
       }
     }
-    // migrates old local storage, will be deleted in future versions
-    var pluginState = window.localStorage;
-
-    Object.keys(pluginState).forEach(key => {
-      if (pluginState[key] === "true" && !key.includes("-")) {
-        this.setPreviewed(key);
-      }
-    });
   }
 
   init() {


### PR DESCRIPTION
previously we used the Chrome storage API along with session storage. There was code in this plugin to migrate both of those to the IDB backend. This commit removes that migration code for two reasons:

1) to remove the reliance on the storage api in the extension manifest
2) to remove confusing code which by this time is (hopefully) no longer needed