### PR TITLE
fix bug causing Waveform to not work when Checkout is running

### DIFF
--- a/src/checkout.js
+++ b/src/checkout.js
@@ -6,7 +6,7 @@ import Logger from "./logger";
 const albumsToPurchase = [1609998585];
 
 export default class Checkout {
-  constructor() {
+  constructor(port) {
     this.log = new Logger();
 
     this.config;
@@ -21,16 +21,7 @@ export default class Checkout {
     this.yesButtonClicked = Checkout.yesButtonClicked.bind(this);
     this.noButtonClicked = Checkout.noButtonClicked.bind(this);
 
-    try {
-      this.port = chrome.runtime.connect(null, { name: "bandcamplabelview" });
-    } catch (e) {
-      if (e.message.includes("Error in invocation of runtime.connect")) {
-        this.log.error(e);
-        return;
-      } else {
-        throw e;
-      }
-    }
+    this.port = port;
   }
 
   init() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+import Logger from "./logger";
 import LabelView from "./label_view.js";
 import DownloadHelper from "./download_helper.js";
 import Player from "./player.js";
@@ -5,6 +6,8 @@ import Waveform from "./waveform.js";
 import Checkout from "./checkout.js";
 
 window.onload = () => {
+  const log = new Logger();
+
   const lv = new LabelView();
   lv.init();
 
@@ -22,10 +25,23 @@ window.onload = () => {
     const player = new Player();
     player.init();
 
-    let waveform = new Waveform();
+
+    let config_port;
+    try {
+      config_port = chrome.runtime.connect(null, { name: "bandcamplabelview" });
+    } catch (e) {
+      if (e.message.includes("Error in invocation of runtime.connect in main.js")) {
+        log.error(e);
+        return;
+      } else {
+        throw e;
+      }
+    }
+
+    let waveform = new Waveform(config_port);
     waveform.init();
 
-    // let checkout = new Checkout();
-    // checkout.init();
+    let checkout = new Checkout(config_port);
+    checkout.init();
   }
 };

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -2,7 +2,7 @@ import Logger from "./logger";
 import { mousedownCallback } from "./utilities.js";
 
 export default class Waveform {
-  constructor() {
+  constructor(port) {
     this.log = new Logger();
 
     this.currentTarget;
@@ -22,17 +22,7 @@ export default class Waveform {
     );
 
     this.applyConfig = Waveform.applyConfig.bind(this);
-
-    try {
-      this.port = chrome.runtime.connect(null, { name: "bandcamplabelview" });
-    } catch (e) {
-      if (e.message.includes("Error in invocation of runtime.connect")) {
-        this.log.error(e);
-        return;
-      } else {
-        throw e;
-      }
-    }
+    this.port = port;
   }
 
   init() {

--- a/test/checkout.js
+++ b/test/checkout.js
@@ -23,47 +23,13 @@ describe("Checkout", () => {
       postMessage: sinon.spy()
     };
 
-    global.chrome = chrome;
-    chrome.runtime.connect.returns(mockPort);
-
-    c = new Checkout();
+    c = new Checkout(mockPort);
 
     sandbox.stub(c, "log");
   });
 
   afterEach(() => {
     sandbox.restore();
-  });
-
-  // NOTE: this is borrowed from waveform tests
-  describe("constructor", () => {
-    describe("chrome communication configuration", () => {
-      it("configures chrome.runtime.connection", () => {
-        new Checkout();
-
-        expect(chrome.runtime.connect).to.be.calledWith(null, {
-          name: "bandcamplabelview"
-        });
-      });
-
-      it("does not throw error if 'Error in invocation'", () => {
-        const error = new Error("Error in invocation of runtime.connect");
-        chrome.runtime.connect.throws(error);
-
-        const throwCheck = () => new Checkout();
-
-        expect(throwCheck).to.not.throw();
-      });
-
-      it("should throw error for all other errors from chrome'", () => {
-        const error = new Error("some error message");
-        chrome.runtime.connect.throws(error);
-
-        const throwCheck = () => new Checkout();
-
-        expect(throwCheck).to.throw();
-      });
-    });
   });
 
   describe("init()", () => {

--- a/test/waveform.js
+++ b/test/waveform.js
@@ -37,10 +37,7 @@ describe("Waveform", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
-    global.chrome = chrome;
-    chrome.runtime.connect.returns(mockPort);
-
-    wf = new Waveform();
+    wf = new Waveform(mockPort);
 
     sandbox.stub(wf, "log");
 
@@ -52,36 +49,6 @@ describe("Waveform", () => {
   afterEach(() => {
     cleanupTestNodes();
     sandbox.restore();
-  });
-
-  describe("constructor", () => {
-    describe("chrome communication configuration", () => {
-      it("configures chrome.runtime.connection", () => {
-        new Waveform();
-
-        expect(chrome.runtime.connect).to.be.calledWith(null, {
-          name: "bandcamplabelview"
-        });
-      });
-
-      it("does not throw error if 'Error in invocation'", () => {
-        const error = new Error("Error in invocation of runtime.connect");
-        chrome.runtime.connect.throws(error);
-
-        const throwCheck = () => new Waveform();
-
-        expect(throwCheck).to.not.throw();
-      });
-
-      it("should throw error for all other errors from chrome'", () => {
-        const error = new Error("some error message");
-        chrome.runtime.connect.throws(error);
-
-        const throwCheck = () => new Waveform();
-
-        expect(throwCheck).to.throw();
-      });
-    });
   });
 
   describe("init()", () => {


### PR DESCRIPTION
Each of the classes was creating its own Chrome port for communication. It appears that only one of those can receive messages from the `config_backend` script. To fix this, a single port is created in `main` and passed to each object that needs access to config.

This pattern makes sense and should be how all classes get access configuration data in the future.