### PR TITLE
catch all 'meta' button keyboard actions 

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -102,6 +102,9 @@ export default class Player {
   static keydownCallback(e) {
     this.log.info("Keydown: " + e.key);
     if (e.target == document.body) {
+      if (e.key == "Meta") {
+        return;
+      }
       if (e.key == " " || e.key == "p") {
         e.preventDefault();
         document.querySelector("div.playbutton").click();

--- a/test/player.js
+++ b/test/player.js
@@ -298,6 +298,15 @@ describe("Player", () => {
       sandbox.restore();
     });
 
+    it("if Meta (CMD on Mac) is pressed, nothing happens", () => {
+      event.key = "Meta";
+      player.keydownCallback(event);
+
+      expect(event.preventDefault).to.have.not.been.called;
+      expect(document.querySelector).to.have.not.been.called;
+      expect(spyElement.click).to.have.not.been.called;
+    });
+
     it("click play button if space or 'p' pushed", () => {
       event.key = "p";
       player.keydownCallback(event);


### PR DESCRIPTION
to prevent capturing default keyboard commands on page