### PR TITLE
add 30 day delay on asking for donations

### DIFF
--- a/src/background/config_backend.js
+++ b/src/background/config_backend.js
@@ -4,7 +4,9 @@ import DBUtils from "../utilities.js";
 const defaultConfig = {
   displayWaveform: false,
   albumPurchasedDuringCheckout: false,
-  albumOnCheckoutDisabled: false
+  albumOnCheckoutDisabled: false,
+  albumPurchaseTimeDelaySeconds: 60 * 60 * 24 * 30, // 30 days
+  installDateUnixSeconds: Math.floor(Date.now() / 1000)
 };
 
 export default class ConfigBackend {

--- a/src/checkout.js
+++ b/src/checkout.js
@@ -61,9 +61,13 @@ export default class Checkout {
   }
 
   static checkoutButtonClicked() {
+    const enough_time_passed =
+      Date.now() / 1000 - this.config.installDateUnixSeconds >
+      this.config.albumPurchaseTimeDelaySeconds;
     if (
       !this.config.albumOnCheckoutDisabled &&
-      !this.config.albumPurchasedDuringCheckout
+      !this.config.albumPurchasedDuringCheckout &&
+      enough_time_passed
     ) {
       this.dialog.style.display = "block";
       return;

--- a/test/checkout.js
+++ b/test/checkout.js
@@ -108,15 +108,23 @@ describe("Checkout", () => {
   });
 
   describe("checkoutButtonClicked()", () => {
+    let clock;
     beforeEach(() => {
       c.closeDialogAndGoToCart = sinon.spy();
       c.dialog = { style: { display: "none" } };
+
+      clock = sinon.useFakeTimers(10);
+    });
+    afterEach(() => {
+      clock.restore();
     });
 
     it("makes dialog appear when checkout button pressed from default configuration", () => {
       c.config = {
+        albumPurchasedDuringCheckout: false,
         albumOnCheckoutDisabled: false,
-        albumPurchasedDuringCheckout: false
+        albumPurchaseTimeDelaySeconds: 0,
+        installDateUnixSeconds: 0
       };
 
       c.checkoutButtonClicked();
@@ -125,25 +133,45 @@ describe("Checkout", () => {
       expect(c.closeDialogAndGoToCart).to.have.not.been.called;
     });
 
-    it("calls checkoutButtonClicked if 'albumOnCheckoutDisabled' in config is true", () => {
+    it("does not display dialog and calls closeDialogAndGoToCart() if 'albumPurchaseTimeDelaySeconds' not greater than current time minus 'installDateUnixSeconds'", () => {
       c.config = {
-        albumOnCheckoutDisabled: true,
-        albumPurchasedDuringCheckout: false
+        albumPurchasedDuringCheckout: false,
+        albumOnCheckoutDisabled: false,
+        albumPurchaseTimeDelaySeconds: 11,
+        installDateUnixSeconds: 0
       };
 
       c.checkoutButtonClicked();
-
+    
+      expect(c.dialog.style.display).to.equal("none");
       expect(c.closeDialogAndGoToCart).to.have.been.called;
     });
 
-    it("calls checkoutButtonClicked if 'albumPurchasedDuringCheckout[status]' in config is true", () => {
+    it("does not display dialog and calls closeDialogAndGoToCart() if 'albumOnCheckoutDisabled' in config is true", () => {
       c.config = {
-        albumOnCheckoutDisabled: false,
-        albumPurchasedDuringCheckout: true
+        albumPurchasedDuringCheckout: false,
+        albumOnCheckoutDisabled: true,
+        albumPurchaseTimeDelaySeconds: 0,
+        installDateUnixSeconds: 0
       };
 
       c.checkoutButtonClicked();
 
+      expect(c.dialog.style.display).to.equal("none");
+      expect(c.closeDialogAndGoToCart).to.have.been.called;
+    });
+
+    it("does not display dialog and calls closeDialogAndGoToCart() if 'albumPurchasedDuringCheckout[status]' in config is true", () => {
+      c.config = {
+        albumPurchasedDuringCheckout: true,
+        albumOnCheckoutDisabled: false,
+        albumPurchaseTimeDelaySeconds: 0,
+        installDateUnixSeconds: 0
+      };
+
+      c.checkoutButtonClicked();
+
+      expect(c.dialog.style.display).to.equal("none");
       expect(c.closeDialogAndGoToCart).to.have.been.called;
     });
   });


### PR DESCRIPTION
for #133, user commented that asking for $ so early isn't great. This PR adds a 30 day delay before asking. The delay is based on the starting date set when they first run the plugin. This was done by giving the "default config" supplied by the `config_backend.js` file a call to Date.now() which will set this value the first time the user runs naything that touches the database.