### PR TITLE
re-implement mouseclick callback to work on both Chrome and Firefox

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2,11 +2,12 @@ import { openDB } from "idb";
 
 export function mousedownCallback(e) {
   const elementOffset = e.offsetX;
-  const elementWidth = e.path[1].offsetWidth;
+  const elementWidth = e.target.offsetWidth;
   const scaleDuration = elementOffset / elementWidth;
 
   let audio = document.querySelector("audio");
   let audioDuration = audio.duration;
+
   audio.currentTime = scaleDuration * audioDuration;
 }
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -24,7 +24,7 @@ describe("mousedownCallback", () => {
 
     let event = {
       offsetX: 1,
-      path: [{ offsetWidth: 0 }, { offsetWidth: 2 }]
+      target: { offsetWidth: 2 }
     };
 
     mousedownCallback(event);


### PR DESCRIPTION
#147

the structure of a "click" element in Chrome and Firefox differed. So a different property is used to get the width of the target element that is clicked.