### PR TITLE
add Stripe links in call to support popup

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -29,7 +29,15 @@
                     </div>
 
                     <div class="section format-section">
-                        Please Consider <a href="https://github.com/sponsors/sabjorn" target="_blank">Sponsoring This Project</a>
+                        Please consider sponsoring this project:
+                        <div class="section format-section" style="display: flex; justify-content: center; align-items: baseline; margin-top: 10px; margin-bottom: 10px;"> 
+                            <form action="https://buy.stripe.com/eVabMj3dUbMcfGE7sv" method="get" target="_blank">
+                                <button type="submit">Subscribe</button>
+                            </form>
+                            <form action="https://donate.stripe.com/28o2bJdSy7vW6647ss" method="get" target="_blank">
+                                <button type="submit" style="margin-left: 5px;">Donate</button>
+                            </form>
+                        </div>
                     </div>
 
                     <div class="section format-section" style="border-top: 1px solid #EDEDED; padding-top:15px">


### PR DESCRIPTION
#157 
these links are a monthly donation link and a one time donation link (set your price)

Below is a screenshot of what the popup now looks like:
<img width="503" alt="Screenshot 2023-07-13 at 5 22 14 PM" src="https://github.com/sabjorn/BandcampEnhancementSuite/assets/910824/4199f4c6-3e0a-4250-a7d6-e72f01bf8bbb">

