### PR TITLE
remove 'getClientId' method and usage in addAlbumToCart method

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -37,13 +37,6 @@ export default class DBUtils {
   }
 }
 
-export function getClientId() {
-  const cart_id = document
-    .querySelector("[data-client-id-and-key]")
-    .getAttribute("data-client-id-and-key");
-  return cart_id.split('"')[1];
-}
-
 export function getUrl() {
   return window.location.href.split("/")[2];
 }
@@ -52,8 +45,7 @@ export function addAlbumToCart(
   item_id,
   unit_price,
   item_type = "a",
-  url = getUrl(),
-  client_id = getClientId()
+  url = getUrl()
 ) {
   return fetch(`https://${url}/cart/cb`, {
     headers: {
@@ -66,7 +58,7 @@ export function addAlbumToCart(
     },
     referrer: "https://halfpastvibe.bandcamp.com/album/vielen-dank",
     referrerPolicy: "no-referrer-when-downgrade",
-    body: `req=add&item_type=${item_type}&item_id=${item_id}&unit_price=${unit_price}&quantity=1&client_id=${client_id}&sync_num=1`,
+    body: `req=add&item_type=${item_type}&item_id=${item_id}&unit_price=${unit_price}&quantity=1&sync_num=1`,
     method: "POST",
     mode: "cors"
   });


### PR DESCRIPTION
this field is no longer used in the request and causes an error when the function is called because the data is no longer on the page