### PR TITLE
Fix/196 block on purchasable

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2,6 +2,7 @@ import Logger from "./logger";
 import {
   mousedownCallback,
   extractBandFollowInfo,
+  extractFanTralbumData,
   getTralbumDetails,
   addAlbumToCart
 } from "./utilities.js";
@@ -24,6 +25,7 @@ export default class Player {
     this.createInputButtonPair = createInputButtonPair;
     this.createShoppingCartItem = createShoppingCartItem;
     this.extractBandFollowInfo = extractBandFollowInfo;
+    this.extractFanTralbumData = extractFanTralbumData;
     this.getTralbumDetails = getTralbumDetails.bind(this);
     this.createInputButtonPair = createInputButtonPair;
     this.createShoppingCartItem = createShoppingCartItem;
@@ -41,6 +43,12 @@ export default class Player {
     Player.movePlaylist();
 
     this.updatePlayerControlInterface();
+
+    const {
+      is_purchased,
+      part_of_purchased_album
+    } = this.extractFanTralbumData();
+    if (is_purchased | part_of_purchased_album) return;
 
     const bandFollowInfo = this.extractBandFollowInfo();
     const tralbumId = bandFollowInfo.tralbum_id;

--- a/src/player.js
+++ b/src/player.js
@@ -53,33 +53,6 @@ export default class Player {
         return response.json();
       })
       .then(tralbumDetails => {
-        const {
-          price,
-          currency,
-          album_id: tralbumId,
-          title: itemTitle,
-          is_purchasable,
-          type
-        } = tralbumDetails;
-        const oneClick = this.createOneClickBuyButton(
-          price,
-          currency,
-          tralbumId,
-          itemTitle,
-          is_purchasable,
-          type
-        );
-
-        const table = document
-          .createRange()
-          .createContextualFragment(emptyPlaylistTable)
-          .querySelector("table");
-
-        document.querySelector("ul.tralbumCommands").prepend(table);
-
-        const downloadCol = table.querySelector(".download-col");
-        downloadCol.append(oneClick);
-
         document.querySelectorAll("tr.track_row_view").forEach((row, i) => {
           if (tralbumDetails.tracks[i] === undefined) return;
 
@@ -103,10 +76,41 @@ export default class Player {
             is_purchasable,
             type
           );
+
+          if (!is_purchasable) return;
+
           const downloadCol = row.querySelector(".download-col");
           downloadCol.innerHTML = "";
           downloadCol.append(oneClick);
         });
+
+        const {
+          price,
+          currency,
+          album_id: tralbumId,
+          title: itemTitle,
+          is_purchasable,
+          type
+        } = tralbumDetails;
+        const oneClick = this.createOneClickBuyButton(
+          price,
+          currency,
+          tralbumId,
+          itemTitle,
+          is_purchasable,
+          type
+        );
+        if (!is_purchasable) return;
+
+        const table = document
+          .createRange()
+          .createContextualFragment(emptyPlaylistTable)
+          .querySelector("table");
+
+        document.querySelector("ul.tralbumCommands").prepend(table);
+
+        const downloadCol = table.querySelector(".download-col");
+        downloadCol.append(oneClick);
       })
       .catch(error => {
         this.log.error(error);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -54,6 +54,21 @@ export function extractBandFollowInfo() {
   }
 }
 
+export function extractFanTralbumData() {
+  const data = document.querySelector("[data-blob]").getAttribute("data-blob");
+
+  if (!data) {
+    return null;
+  }
+
+  try {
+    const { fan_tralbum_data } = JSON.parse(data);
+    return fan_tralbum_data;
+  } catch (error) {
+    return null;
+  }
+}
+
 export function getUrl() {
   return window.location.href.split("/")[2];
 }

--- a/test/player.js
+++ b/test/player.js
@@ -199,17 +199,18 @@ describe("Player", () => {
       it("should modify DOM correctly", async () => {
         await player.init();
 
-        const album = document.querySelector("ul.tralbumCommands");
-        expect(album.querySelectorAll("#unique-id-0")).to.have.length(1);
-
         const rows = document.querySelectorAll("tr.track_row_view");
         expect(rows).to.have.length(2);
+        expect(rows[0].querySelector(".info-col")).to.be.null;
+        expect(rows[0].querySelectorAll(".download-col")).to.have.length(1);
+        expect(rows[0].querySelectorAll(`#unique-id-0`)).to.have.length(0); // is purchasable == false
 
-        rows.forEach((row, i) => {
-          expect(row.querySelector(".info-col")).to.be.null;
-          expect(row.querySelectorAll(".download-col")).to.have.length(1);
-          expect(row.querySelectorAll(`#unique-id-${i + 1}`)).to.have.length(1);
-        });
+        expect(rows[1].querySelector(".info-col")).to.be.null;
+        expect(rows[1].querySelectorAll(".download-col")).to.have.length(1);
+        expect(rows[1].querySelectorAll(`#unique-id-1`)).to.have.length(1);
+
+        const album = document.querySelector("ul.tralbumCommands");
+        expect(album.querySelectorAll("#unique-id-2")).to.have.length(1);
       });
 
       it("should not fail if more DOM elements than tralbumDetail tracks", async () => {

--- a/test/player.js
+++ b/test/player.js
@@ -91,6 +91,12 @@ describe("Player", () => {
           Object.assign(document.createElement("div"), { id: "unique-id-2" })
         );
       player.getTralbumDetails = sinon.stub().resolves(mockResponse);
+      player.extractFanTralbumData = sinon.stub().resolves({
+        fan_tralbum_data: {
+          is_purchased: true,
+          part_of_purchased_album: false
+        }
+      });
 
       createDomNodes(`
         <table class="track_list track_table" id="track_table">

--- a/test/player.js
+++ b/test/player.js
@@ -91,11 +91,9 @@ describe("Player", () => {
           Object.assign(document.createElement("div"), { id: "unique-id-2" })
         );
       player.getTralbumDetails = sinon.stub().resolves(mockResponse);
-      player.extractFanTralbumData = sinon.stub().resolves({
-        fan_tralbum_data: {
-          is_purchased: true,
-          part_of_purchased_album: false
-        }
+      player.extractFanTralbumData = sinon.stub().returns({
+        is_purchased: false,
+        part_of_purchased_album: false
       });
 
       createDomNodes(`
@@ -169,16 +167,6 @@ describe("Player", () => {
         expect(
           player.createOneClickBuyButton.getCall(0)
         ).to.have.been.calledWithExactly(
-          mockTralbumDetails.price,
-          mockTralbumDetails.currency,
-          mockTralbumDetails.album_id,
-          mockTralbumDetails.title,
-          mockTralbumDetails.is_purchasable,
-          mockTralbumDetails.type
-        );
-        expect(
-          player.createOneClickBuyButton.getCall(1)
-        ).to.have.been.calledWithExactly(
           mockTralbumDetails.tracks[0].price,
           mockTralbumDetails.tracks[0].currency,
           mockTralbumDetails.tracks[0].track_id,
@@ -187,7 +175,7 @@ describe("Player", () => {
           "t"
         );
         expect(
-          player.createOneClickBuyButton.getCall(2)
+          player.createOneClickBuyButton.getCall(1)
         ).to.have.been.calledWithExactly(
           mockTralbumDetails.tracks[1].price,
           mockTralbumDetails.tracks[1].currency,
@@ -195,6 +183,16 @@ describe("Player", () => {
           mockTralbumDetails.tracks[1].title,
           mockTralbumDetails.tracks[1].is_purchasable,
           "t"
+        );
+        expect(
+          player.createOneClickBuyButton.getCall(2)
+        ).to.have.been.calledWithExactly(
+          mockTralbumDetails.price,
+          mockTralbumDetails.currency,
+          mockTralbumDetails.album_id,
+          mockTralbumDetails.title,
+          mockTralbumDetails.is_purchasable,
+          mockTralbumDetails.type
         );
       });
 
@@ -252,6 +250,39 @@ describe("Player", () => {
         await player.init();
 
         expect(player.createOneClickBuyButton).to.be.calledOnce;
+      });
+
+      it("should not setup 1-click if 'is_purchased' or 'part_of_purchased_album'", async () => {
+        {
+          player.extractFanTralbumData = sinon.stub().returns({
+            is_purchased: true,
+            part_of_purchased_album: false
+          });
+
+          await player.init();
+
+          expect(player.getTralbumDetails).to.be.not.called;
+        }
+        {
+          player.extractFanTralbumData = sinon.stub().returns({
+            is_purchased: false,
+            part_of_purchased_album: true
+          });
+
+          await player.init();
+
+          expect(player.getTralbumDetails).to.be.not.called;
+        }
+        {
+          player.extractFanTralbumData = sinon.stub().returns({
+            is_purchased: true,
+            part_of_purchased_album: true
+          });
+
+          await player.init();
+
+          expect(player.getTralbumDetails).to.be.not.called;
+        }
       });
     });
 


### PR DESCRIPTION
fixes the issue where non-purchasable tracks/albums display "undefined" instead of a + button
adds a feature to skip album/tracks if already purchased