### PR TITLE
Fix/202 broken 1click buy

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -12,6 +12,7 @@ import { createPlusSvgIcon } from "./components/svgIcons";
 
 const stepSize = 10;
 const CURRENCY_MINIMUMS = {
+  USD: 0.5,
   AUD: 0.5,
   GBP: 0.25,
   CAD: 1.0,
@@ -90,14 +91,17 @@ export default class Player {
           } = tralbumDetails.tracks[i];
           const type = "t";
 
-          if (price === 0.0) return;
           if (!is_purchasable) return;
 
           const infoCol = row.querySelector(".info-col");
           if (infoCol) infoCol.remove();
 
+          const minimumPrice =
+            price > 0.0 ? price : CURRENCY_MINIMUMS[currency];
+          if (!minimumPrice) return;
+
           const oneClick = this.createOneClickBuyButton(
-            price,
+            minimumPrice,
             currency,
             tralbumId,
             itemTitle,
@@ -118,10 +122,12 @@ export default class Player {
           is_purchasable,
           type
         } = tralbumDetails;
-        if (price === 0.0) return;
         if (!is_purchasable) return;
+
+        const minimumPrice = price > 0.0 ? price : CURRENCY_MINIMUMS[currency];
+        if (!minimumPrice) return;
         const oneClick = this.createOneClickBuyButton(
-          price,
+          minimumPrice,
           currency,
           tralbumId,
           itemTitle,

--- a/src/player.js
+++ b/src/player.js
@@ -11,6 +11,25 @@ import { createShoppingCartItem } from "./components/shoppingCart.js";
 import { createPlusSvgIcon } from "./components/svgIcons";
 
 const stepSize = 10;
+const CURRENCY_MINIMUMS = {
+  AUD: 0.5,
+  GBP: 0.25,
+  CAD: 1.0,
+  EUR: 0.25,
+  JPY: 70,
+  CZK: 10,
+  DKK: 2.5,
+  HKD: 2.5,
+  HUF: 100,
+  ILS: 1.5,
+  MXN: 5,
+  NZD: 0.5,
+  NOK: 3,
+  PLN: 3,
+  SGD: 1,
+  SEK: 3,
+  CHF: 0.5
+};
 
 export default class Player {
   constructor() {

--- a/src/player.js
+++ b/src/player.js
@@ -71,6 +71,9 @@ export default class Player {
           } = tralbumDetails.tracks[i];
           const type = "t";
 
+          if (price === 0.0) return;
+          if (!is_purchasable) return;
+
           const infoCol = row.querySelector(".info-col");
           if (infoCol) infoCol.remove();
 
@@ -82,8 +85,6 @@ export default class Player {
             is_purchasable,
             type
           );
-
-          if (!is_purchasable) return;
 
           const downloadCol = row.querySelector(".download-col");
           downloadCol.innerHTML = "";
@@ -98,6 +99,8 @@ export default class Player {
           is_purchasable,
           type
         } = tralbumDetails;
+        if (price === 0.0) return;
+        if (!is_purchasable) return;
         const oneClick = this.createOneClickBuyButton(
           price,
           currency,
@@ -106,7 +109,6 @@ export default class Player {
           is_purchasable,
           type
         );
-        if (!is_purchasable) return;
 
         document
           .querySelector("ul.tralbumCommands .buyItem.digital h3.hd")

--- a/src/player.js
+++ b/src/player.js
@@ -41,7 +41,6 @@ export default class Player {
     Player.movePlaylist();
 
     this.updatePlayerControlInterface();
-    return;
 
     const {
       is_purchased,

--- a/src/player.js
+++ b/src/player.js
@@ -105,7 +105,6 @@ export default class Player {
             currency,
             tralbumId,
             itemTitle,
-            is_purchasable,
             type
           );
 
@@ -131,7 +130,6 @@ export default class Player {
           currency,
           tralbumId,
           itemTitle,
-          is_purchasable,
           type
         );
 
@@ -272,18 +270,7 @@ export default class Player {
     this.log.info("volume:", volume);
   }
 
-  static createOneClickBuyButton(
-    price,
-    currency,
-    tralbumId,
-    itemTitle,
-    is_purchasable,
-    type
-  ) {
-    if (!is_purchasable) {
-      return;
-    }
-
+  static createOneClickBuyButton(price, currency, tralbumId, itemTitle, type) {
     const pair = this.createInputButtonPair({
       inputPrefix: "$",
       inputSuffix: currency,

--- a/test/player.js
+++ b/test/player.js
@@ -171,7 +171,7 @@ describe("Player", () => {
       expect(Player.movePlaylist).to.have.been.called;
     });
 
-    xdescribe("add one click add to cart buttons", () => {
+    describe("add one click add to cart buttons", () => {
       it("should be called for each track and album when getTralbumDetails succeeds", async () => {
         await player.init();
 
@@ -305,7 +305,7 @@ describe("Player", () => {
       });
     });
 
-    xit("should handle errors when getTralbumDetails fails", async () => {
+    it("should handle errors when getTralbumDetails fails", async () => {
       const errorMessage = "HTTP error! status: 404";
       player.getTralbumDetails.rejects(new Error(errorMessage));
 


### PR DESCRIPTION
(hopefully) fixes the issue where the cart would disappear by removing the ability to add $0 items to the cart. A $0 item is not a legal cart entry -- which can be seen when you attempt to add a $0 item in the regular Bandcamp workflow -- it skips the ability to add to cart and instead gives a way to directly download (skipping adding to your collection).

This PR provides a fix by mapping any $0 item to the minimum value for that currency. The minimum currency values were found by finding one $0 item for reach currency type and trying to buy it for $0.01 -- in which case Bandcamp tells you the minimum.