### PR TITLE
update add to cart code to use 'id' instead of 'album_id' for key

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -116,7 +116,7 @@ export default class Player {
         const {
           price,
           currency,
-          album_id: tralbumId,
+          id: tralbumId,
           title: itemTitle,
           is_purchasable,
           type

--- a/test/player.js
+++ b/test/player.js
@@ -44,7 +44,7 @@ describe("Player", () => {
     const mockTralbumDetails = {
       price: "5.00",
       currency: "USD",
-      album_id: "987",
+      id: "987",
       title: "Test Album",
       is_purchasable: true,
       type: "a",
@@ -194,7 +194,7 @@ describe("Player", () => {
         ).to.have.been.calledWithExactly(
           mockTralbumDetails.price,
           mockTralbumDetails.currency,
-          mockTralbumDetails.album_id,
+          mockTralbumDetails.id,
           mockTralbumDetails.title,
           mockTralbumDetails.type
         );
@@ -224,7 +224,7 @@ describe("Player", () => {
         const mockTralbumDetails = {
           price: "5.00",
           currency: "USD",
-          album_id: "987",
+          id: "987",
           title: "Test Album",
           is_purchasable: true,
           type: "a",
@@ -346,7 +346,7 @@ describe("Player", () => {
         const mockTralbumDetails = {
           price: "0.0",
           currency: "GEK",
-          album_id: "987",
+          id: "987",
           title: "Test Album",
           is_purchasable: true,
           type: "a",


### PR DESCRIPTION
If it is a track page -- the `album_id`  -- since if it is a track page this value will be 'null'