### PR TITLE
Reorganize drawer: move FindMusic.club to top and enlarge Settings heading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -422,7 +422,7 @@ button.bes-downloadall[disabled]::after {
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 9998;
+  z-index: 10001;
   opacity: 0;
   visibility: hidden;
   transition:
@@ -444,7 +444,7 @@ button.bes-downloadall[disabled]::after {
   height: 100%;
   background: #fff;
   box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
-  z-index: 9999;
+  z-index: 10002;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   display: flex;
@@ -597,7 +597,9 @@ button.bes-downloadall[disabled]::after {
 .bes-keyboard-section-content {
   max-height: 2000px;
   overflow: hidden;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition:
+    max-height 0.3s ease,
+    opacity 0.3s ease;
   opacity: 1;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -569,6 +569,41 @@ button.bes-downloadall[disabled]::after {
   margin-bottom: 32px;
 }
 
+.bes-keyboard-section-header {
+  margin-bottom: 8px;
+}
+
+.bes-keyboard-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  user-select: none;
+  transition: color 0.2s ease;
+}
+
+.bes-keyboard-section-title:hover {
+  color: #1da0c3;
+}
+
+.bes-keyboard-section-arrow {
+  font-size: 12px;
+  transition: transform 0.2s ease;
+  display: inline-block;
+}
+
+.bes-keyboard-section-content {
+  max-height: 2000px;
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  opacity: 1;
+}
+
+.bes-keyboard-section-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+
 .bes-keyboard-description {
   margin: 0 0 20px 0;
   font-size: 13px;

--- a/css/style.css
+++ b/css/style.css
@@ -590,6 +590,8 @@ button.bes-downloadall[disabled]::after {
   font-size: 12px;
   transition: transform 0.2s ease;
   display: inline-block;
+  width: 12px;
+  text-align: center;
 }
 
 .bes-keyboard-section-content {
@@ -743,6 +745,55 @@ button.bes-downloadall[disabled]::after {
 .bes-keyboard-step-input:focus {
   outline: none;
   border-color: #1da0c3;
+}
+
+.bes-keyboard-reset-container {
+  margin-top: 24px;
+}
+
+.bes-keyboard-reset-confirmation {
+  padding: 16px;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 6px;
+}
+
+.bes-keyboard-reset-confirmation-text {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: #333;
+  text-align: center;
+}
+
+.bes-keyboard-reset-confirmation-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.bes-keyboard-confirm-button {
+  background: #dc3545;
+  flex: 1;
+}
+
+.bes-keyboard-confirm-button:hover {
+  background: #c82333;
+}
+
+.bes-keyboard-confirm-button:active {
+  background: #bd2130;
+}
+
+.bes-keyboard-cancel-button {
+  background: #6c757d;
+  flex: 1;
+}
+
+.bes-keyboard-cancel-button:hover {
+  background: #5a6268;
+}
+
+.bes-keyboard-cancel-button:active {
+  background: #545b62;
 }
 
 .bes-keyboard-reset-button {

--- a/css/style.css
+++ b/css/style.css
@@ -563,3 +563,162 @@ button.bes-downloadall[disabled]::after {
   margin: 0;
   pointer-events: all;
 }
+
+/* Keyboard Settings Styles */
+.bes-keyboard-section {
+  margin-bottom: 32px;
+}
+
+.bes-keyboard-description {
+  margin: 0 0 20px 0;
+  font-size: 13px;
+  color: #666;
+  line-height: 1.5;
+}
+
+.bes-keyboard-category-section {
+  margin-bottom: 24px;
+}
+
+.bes-keyboard-category-header {
+  margin: 16px 0 12px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1da0c3;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 6px;
+}
+
+.bes-keyboard-control-row {
+  display: grid;
+  grid-template-columns: 30px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid #f0f0f0;
+  transition: opacity 0.2s ease;
+}
+
+.bes-keyboard-control-row:last-child {
+  border-bottom: none;
+}
+
+.bes-keyboard-control-row.disabled {
+  opacity: 0.5;
+}
+
+.bes-keyboard-control-row.conflict {
+  background-color: #fff3cd;
+  padding: 10px;
+  margin: 0 -10px;
+  border-radius: 4px;
+  border: 1px solid #ffc107;
+}
+
+.bes-keyboard-control-enable-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bes-keyboard-control-enable {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+}
+
+.bes-keyboard-control-description {
+  font-size: 14px;
+  color: #333;
+}
+
+.bes-key-binding-editor-container {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.bes-key-binding-display {
+  padding: 6px 12px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: 'Courier New', monospace;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
+  min-width: 100px;
+  text-align: center;
+}
+
+.bes-key-binding-display:hover {
+  background: #e8e8e8;
+  border-color: #1da0c3;
+}
+
+.bes-key-binding-display.recording {
+  background: #1da0c3;
+  color: white;
+  border-color: #1da0c3;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.bes-keyboard-step-sizes {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 2px solid #e0e0e0;
+}
+
+.bes-keyboard-step-input-container {
+  margin-bottom: 12px;
+}
+
+.bes-keyboard-step-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  color: #333;
+  margin-bottom: 4px;
+}
+
+.bes-keyboard-step-input {
+  width: 80px;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  text-align: right;
+}
+
+.bes-keyboard-step-input:focus {
+  outline: none;
+  border-color: #1da0c3;
+}
+
+.bes-keyboard-reset-button {
+  margin-top: 16px;
+  background: #6c757d;
+}
+
+.bes-keyboard-reset-button:hover {
+  background: #5a6268;
+}
+
+.bes-keyboard-reset-button:active {
+  background: #545b62;
+}

--- a/src/background/config_backend.ts
+++ b/src/background/config_backend.ts
@@ -111,7 +111,6 @@ export async function updateKeyboardSettings(
 ): Promise<void> {
   log.info('updating keyboard settings');
 
-  // Validate settings
   const errors = validateKeyboardSettings(settings);
   if (errors.length > 0) {
     log.error(`Invalid keyboard settings: ${errors.join(', ')}`);

--- a/src/background/config_backend.ts
+++ b/src/background/config_backend.ts
@@ -119,8 +119,7 @@ export async function updateKeyboardSettings(
     return;
   }
 
-  // Get current config and update keyboard settings
-  let db_config = await db.get('config', 'config');
+  const db_config = await db.get('config', 'config');
   db_config['keyboardSettings'] = settings;
   await db.put('config', db_config, 'config');
   port?.postMessage({ config: db_config });
@@ -129,7 +128,7 @@ export async function updateKeyboardSettings(
 export async function resetKeyboardSettings(db: any, log: Logger, port?: chrome.runtime.Port): Promise<void> {
   log.info('resetting keyboard settings to defaults');
 
-  let db_config = await db.get('config', 'config');
+  const db_config = await db.get('config', 'config');
   db_config['keyboardSettings'] = DEFAULT_KEYBOARD_SETTINGS;
   await db.put('config', db_config, 'config');
   port?.postMessage({ config: db_config });

--- a/src/background/config_backend.ts
+++ b/src/background/config_backend.ts
@@ -1,5 +1,6 @@
 import Logger from '../logger.js';
 import { getDB } from '../utilities.js';
+import { KeyboardSettings, DEFAULT_KEYBOARD_SETTINGS, validateKeyboardSettings } from '../types/keyboard.js';
 
 interface Config {
   displayWaveform: boolean;
@@ -7,6 +8,7 @@ interface Config {
   albumOnCheckoutDisabled: boolean;
   albumPurchaseTimeDelaySeconds: number;
   installDateUnixSeconds: number;
+  keyboardSettings?: KeyboardSettings;
 }
 
 const defaultConfig: Config = {
@@ -14,7 +16,8 @@ const defaultConfig: Config = {
   albumPurchasedDuringCheckout: false,
   albumOnCheckoutDisabled: false,
   albumPurchaseTimeDelaySeconds: 60 * 60 * 24 * 30,
-  installDateUnixSeconds: Math.floor(Date.now() / 1000)
+  installDateUnixSeconds: Math.floor(Date.now() / 1000),
+  keyboardSettings: DEFAULT_KEYBOARD_SETTINGS
 };
 
 export function connectionListenerCallback(
@@ -47,6 +50,10 @@ export async function portListenerCallback(
   if (msg.config) await synchronizeConfig(db, msg.config, portState.port);
 
   if (msg.toggleWaveformDisplay) await toggleWaveformDisplay(db, log, portState.port);
+
+  if (msg.updateKeyboardSettings) await updateKeyboardSettings(db, msg.updateKeyboardSettings, log, portState.port);
+
+  if (msg.resetKeyboardSettings) await resetKeyboardSettings(db, log, portState.port);
 
   if (msg.requestConfig) await broadcastConfig(db, log, portState.port);
 }
@@ -94,4 +101,36 @@ export async function setupDB(db: any): Promise<void> {
 
 export function mergeData(reference_config: Config, new_config: Partial<Config>): Config {
   return Object.assign({}, reference_config, new_config);
+}
+
+export async function updateKeyboardSettings(
+  db: any,
+  settings: KeyboardSettings,
+  log: Logger,
+  port?: chrome.runtime.Port
+): Promise<void> {
+  log.info('updating keyboard settings');
+
+  // Validate settings
+  const errors = validateKeyboardSettings(settings);
+  if (errors.length > 0) {
+    log.error(`Invalid keyboard settings: ${errors.join(', ')}`);
+    port?.postMessage({ keyboardSettingsError: errors });
+    return;
+  }
+
+  // Get current config and update keyboard settings
+  let db_config = await db.get('config', 'config');
+  db_config['keyboardSettings'] = settings;
+  await db.put('config', db_config, 'config');
+  port?.postMessage({ config: db_config });
+}
+
+export async function resetKeyboardSettings(db: any, log: Logger, port?: chrome.runtime.Port): Promise<void> {
+  log.info('resetting keyboard settings to defaults');
+
+  let db_config = await db.get('config', 'config');
+  db_config['keyboardSettings'] = DEFAULT_KEYBOARD_SETTINGS;
+  await db.put('config', db_config, 'config');
+  port?.postMessage({ config: db_config });
 }

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -1,0 +1,326 @@
+/**
+ * UI components for keyboard settings configuration
+ */
+
+import {
+  KeyBinding,
+  KeyboardAction,
+  KeyboardSettings,
+  KeyboardControlSetting,
+  ACTION_DESCRIPTIONS,
+  ACTION_CATEGORIES,
+  ActionCategory,
+  keyBindingToString,
+  keyBindingsEqual
+} from '../types/keyboard.js';
+
+interface KeyBindingEditorCallbacks {
+  onBindingChange: (newBinding: KeyBinding) => void;
+  onCancel?: () => void;
+}
+
+/**
+ * Creates an interactive key binding editor that captures key presses
+ */
+export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: KeyBindingEditorCallbacks): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'bes-key-binding-editor-container';
+
+  const display = document.createElement('button');
+  display.className = 'bes-key-binding-display';
+  display.textContent = keyBindingToString(currentBinding);
+  display.title = 'Click to change key binding';
+
+  let isRecording = false;
+
+  const startRecording = () => {
+    isRecording = true;
+    display.classList.add('recording');
+    display.textContent = 'Press any key...';
+  };
+
+  const stopRecording = () => {
+    isRecording = false;
+    display.classList.remove('recording');
+    display.textContent = keyBindingToString(currentBinding);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!isRecording) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Cancel on Escape
+    if (e.key === 'Escape') {
+      stopRecording();
+      callbacks.onCancel?.();
+      return;
+    }
+
+    // Ignore modifier-only presses
+    if (['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) {
+      return;
+    }
+
+    const newBinding: KeyBinding = {
+      key: e.key,
+      shift: e.shiftKey,
+      alt: e.altKey,
+      ctrl: e.ctrlKey,
+      meta: e.metaKey
+    };
+
+    // Update current binding
+    Object.assign(currentBinding, newBinding);
+    stopRecording();
+    callbacks.onBindingChange(newBinding);
+  };
+
+  display.addEventListener('click', e => {
+    e.preventDefault();
+    if (!isRecording) {
+      startRecording();
+    }
+  });
+
+  // Add global keydown listener when recording
+  document.addEventListener('keydown', handleKeyDown);
+
+  container.appendChild(display);
+
+  return container;
+}
+
+/**
+ * Creates a number input for step size settings
+ */
+function createStepSizeInput(
+  label: string,
+  currentValue: number,
+  min: number,
+  max: number,
+  step: number,
+  onChange: (value: number) => void
+): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'bes-keyboard-step-input-container';
+
+  const labelElement = document.createElement('label');
+  labelElement.textContent = label;
+  labelElement.className = 'bes-keyboard-step-label';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.className = 'bes-keyboard-step-input';
+  input.min = min.toString();
+  input.max = max.toString();
+  input.step = step.toString();
+  input.value = currentValue.toString();
+
+  input.addEventListener('change', () => {
+    const value = parseFloat(input.value);
+    if (!isNaN(value) && value >= min && value <= max) {
+      onChange(value);
+    } else {
+      input.value = currentValue.toString();
+    }
+  });
+
+  labelElement.appendChild(input);
+  container.appendChild(labelElement);
+
+  return container;
+}
+
+/**
+ * Creates a row for a single keyboard control setting
+ */
+function createKeyboardControlRow(
+  control: KeyboardControlSetting,
+  settings: KeyboardSettings,
+  onUpdate: (updatedSettings: KeyboardSettings) => void
+): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'bes-keyboard-control-row';
+
+  // Description
+  const description = document.createElement('span');
+  description.className = 'bes-keyboard-control-description';
+  description.textContent = ACTION_DESCRIPTIONS[control.action];
+
+  // Enable/disable checkbox
+  const enableCheckbox = document.createElement('input');
+  enableCheckbox.type = 'checkbox';
+  enableCheckbox.checked = control.enabled;
+  enableCheckbox.className = 'bes-keyboard-control-enable';
+
+  enableCheckbox.addEventListener('change', () => {
+    control.enabled = enableCheckbox.checked;
+    row.classList.toggle('disabled', !control.enabled);
+    onUpdate({ ...settings });
+  });
+
+  // Key binding editor
+  const editor = createKeyBindingEditor(control.binding, {
+    onBindingChange: newBinding => {
+      control.binding = newBinding;
+
+      // Check for conflicts
+      const conflicts = settings.controls.filter(
+        c => c.enabled && c.action !== control.action && keyBindingsEqual(c.binding, newBinding)
+      );
+
+      if (conflicts.length > 0) {
+        const conflictNames = conflicts.map(c => ACTION_DESCRIPTIONS[c.action]).join(', ');
+        row.classList.add('conflict');
+        row.title = `Conflicts with: ${conflictNames}`;
+      } else {
+        row.classList.remove('conflict');
+        row.title = '';
+      }
+
+      onUpdate({ ...settings });
+    }
+  });
+
+  if (!control.enabled) {
+    row.classList.add('disabled');
+  }
+
+  const enableContainer = document.createElement('div');
+  enableContainer.className = 'bes-keyboard-control-enable-container';
+  enableContainer.appendChild(enableCheckbox);
+
+  row.appendChild(enableContainer);
+  row.appendChild(description);
+  row.appendChild(editor);
+
+  return row;
+}
+
+/**
+ * Creates a category section with grouped controls
+ */
+function createCategorySection(
+  category: ActionCategory,
+  controls: KeyboardControlSetting[],
+  settings: KeyboardSettings,
+  onUpdate: (updatedSettings: KeyboardSettings) => void
+): HTMLElement {
+  const section = document.createElement('div');
+  section.className = 'bes-keyboard-category-section';
+
+  const header = document.createElement('h4');
+  header.className = 'bes-keyboard-category-header';
+  header.textContent = category;
+
+  section.appendChild(header);
+
+  controls.forEach(control => {
+    const row = createKeyboardControlRow(control, settings, onUpdate);
+    section.appendChild(row);
+  });
+
+  return section;
+}
+
+/**
+ * Creates the complete keyboard settings section for the drawer
+ */
+export function createKeyboardSettingsSection(
+  settings: KeyboardSettings,
+  onUpdate: (updatedSettings: KeyboardSettings) => void
+): HTMLElement {
+  const section = document.createElement('div');
+  section.className = 'bes-drawer-section bes-keyboard-section';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Keyboard Controls';
+
+  const description = document.createElement('p');
+  description.className = 'bes-keyboard-description';
+  description.textContent = 'Customize keyboard shortcuts for player controls. Click a key binding to change it.';
+
+  section.appendChild(title);
+  section.appendChild(description);
+
+  // Group controls by category
+  const controlsByCategory = new Map<ActionCategory, KeyboardControlSetting[]>();
+
+  settings.controls.forEach(control => {
+    const category = ACTION_CATEGORIES[control.action];
+    if (!controlsByCategory.has(category)) {
+      controlsByCategory.set(category, []);
+    }
+    controlsByCategory.get(category)!.push(control);
+  });
+
+  // Create sections for each category
+  const categoryOrder = [ActionCategory.PLAYBACK, ActionCategory.SEEKING, ActionCategory.VOLUME];
+
+  categoryOrder.forEach(category => {
+    const controls = controlsByCategory.get(category);
+    if (controls && controls.length > 0) {
+      const categorySection = createCategorySection(category, controls, settings, onUpdate);
+      section.appendChild(categorySection);
+    }
+  });
+
+  // Step size settings
+  const stepSizesSection = document.createElement('div');
+  stepSizesSection.className = 'bes-keyboard-step-sizes';
+
+  const stepSizesHeader = document.createElement('h4');
+  stepSizesHeader.className = 'bes-keyboard-category-header';
+  stepSizesHeader.textContent = 'Step Sizes';
+
+  stepSizesSection.appendChild(stepSizesHeader);
+
+  // Seek step size
+  const seekStepInput = createStepSizeInput('Seek step (seconds):', settings.seekStepSize, 1, 60, 1, value => {
+    settings.seekStepSize = value;
+    onUpdate({ ...settings });
+  });
+  stepSizesSection.appendChild(seekStepInput);
+
+  // Large seek step size
+  const largeSeekStepInput = createStepSizeInput(
+    'Large seek step (seconds):',
+    settings.largeSeekStepSize,
+    1,
+    120,
+    1,
+    value => {
+      settings.largeSeekStepSize = value;
+      onUpdate({ ...settings });
+    }
+  );
+  stepSizesSection.appendChild(largeSeekStepInput);
+
+  // Volume step
+  const volumeStepInput = createStepSizeInput('Volume step:', settings.volumeStep, 0.01, 0.5, 0.01, value => {
+    settings.volumeStep = value;
+    onUpdate({ ...settings });
+  });
+  stepSizesSection.appendChild(volumeStepInput);
+
+  section.appendChild(stepSizesSection);
+
+  // Reset button
+  const resetButton = document.createElement('button');
+  resetButton.className = 'bes-drawer-button bes-keyboard-reset-button';
+  resetButton.textContent = 'Reset to Defaults';
+
+  resetButton.addEventListener('click', () => {
+    if (confirm('Reset all keyboard settings to defaults?')) {
+      // This will be handled by sending a message to the backend
+      const resetEvent = new CustomEvent('bes-reset-keyboard-settings');
+      document.dispatchEvent(resetEvent);
+    }
+  });
+
+  section.appendChild(resetButton);
+
+  return section;
+}

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -104,11 +104,11 @@ function createStepSizeInput(
 
   input.addEventListener('change', () => {
     const value = parseFloat(input.value);
-    if (!isNaN(value) && value >= min) {
-      onChange(value);
-    } else {
+    if (isNaN(value) || value < min) {
       input.value = currentValue.toString();
+      return;
     }
+    onChange(value);
   });
 
   labelElement.appendChild(input);
@@ -148,15 +148,16 @@ function createKeyboardControlRow(
         c => c.enabled && c.action !== control.action && keyBindingsEqual(c.binding, newBinding)
       );
 
-      if (conflicts.length > 0) {
-        const conflictNames = conflicts.map(c => ACTION_DESCRIPTIONS[c.action]).join(', ');
-        row.classList.add('conflict');
-        row.title = `Conflicts with: ${conflictNames}`;
-      } else {
+      if (conflicts.length === 0) {
         row.classList.remove('conflict');
         row.title = '';
+        onUpdate({ ...settings });
+        return;
       }
 
+      const conflictNames = conflicts.map(c => ACTION_DESCRIPTIONS[c.action]).join(', ');
+      row.classList.add('conflict');
+      row.title = `Conflicts with: ${conflictNames}`;
       onUpdate({ ...settings });
     }
   });
@@ -176,9 +177,6 @@ function createKeyboardControlRow(
   return row;
 }
 
-/**
- * Creates a category section with grouped controls
- */
 function createCategorySection(
   category: ActionCategory,
   controls: KeyboardControlSetting[],
@@ -342,9 +340,9 @@ export function createKeyboardSettingsSection(
   const updateResetVisibility = () => {
     if (areSettingsModified(settings)) {
       resetContainer.style.display = 'block';
-    } else {
-      resetContainer.style.display = 'none';
+      return;
     }
+    resetContainer.style.display = 'none';
   };
 
   updateResetVisibilityFn = updateResetVisibility;

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -340,20 +340,60 @@ export function createKeyboardSettingsSection(
 
   content.appendChild(stepSizesSection);
 
-  // Reset button
+  // Reset button and confirmation
+  const resetContainer = document.createElement('div');
+  resetContainer.className = 'bes-keyboard-reset-container';
+
   const resetButton = document.createElement('button');
   resetButton.className = 'bes-drawer-button bes-keyboard-reset-button';
   resetButton.textContent = 'Reset to Defaults';
 
+  const confirmationUI = document.createElement('div');
+  confirmationUI.className = 'bes-keyboard-reset-confirmation';
+  confirmationUI.style.display = 'none';
+
+  const confirmationText = document.createElement('p');
+  confirmationText.className = 'bes-keyboard-reset-confirmation-text';
+  confirmationText.textContent = 'Reset all keyboard settings to defaults?';
+
+  const confirmationButtons = document.createElement('div');
+  confirmationButtons.className = 'bes-keyboard-reset-confirmation-buttons';
+
+  const confirmButton = document.createElement('button');
+  confirmButton.className = 'bes-drawer-button bes-keyboard-confirm-button';
+  confirmButton.textContent = 'Reset';
+
+  const cancelButton = document.createElement('button');
+  cancelButton.className = 'bes-drawer-button bes-keyboard-cancel-button';
+  cancelButton.textContent = 'Cancel';
+
+  confirmationButtons.appendChild(confirmButton);
+  confirmationButtons.appendChild(cancelButton);
+  confirmationUI.appendChild(confirmationText);
+  confirmationUI.appendChild(confirmationButtons);
+
   resetButton.addEventListener('click', () => {
-    if (confirm('Reset all keyboard settings to defaults?')) {
-      // This will be handled by sending a message to the backend
-      const resetEvent = new CustomEvent('bes-reset-keyboard-settings');
-      document.dispatchEvent(resetEvent);
-    }
+    resetButton.style.display = 'none';
+    confirmationUI.style.display = 'block';
   });
 
-  content.appendChild(resetButton);
+  confirmButton.addEventListener('click', () => {
+    // This will be handled by sending a message to the backend
+    const resetEvent = new CustomEvent('bes-reset-keyboard-settings');
+    document.dispatchEvent(resetEvent);
+    // Hide confirmation and show reset button again
+    confirmationUI.style.display = 'none';
+    resetButton.style.display = 'block';
+  });
+
+  cancelButton.addEventListener('click', () => {
+    confirmationUI.style.display = 'none';
+    resetButton.style.display = 'block';
+  });
+
+  resetContainer.appendChild(resetButton);
+  resetContainer.appendChild(confirmationUI);
+  content.appendChild(resetContainer);
 
   section.appendChild(content);
 

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -331,11 +331,12 @@ export function createKeyboardSettingsSection(
 
     if (current.controls.length !== DEFAULT_KEYBOARD_SETTINGS.controls.length) return true;
 
-    for (let i = 0; i < current.controls.length; i++) {
-      const currentControl = current.controls[i];
-      const defaultControl = DEFAULT_KEYBOARD_SETTINGS.controls[i];
+    const currentByAction = new Map(current.controls.map(c => [c.action, c]));
 
-      if (currentControl.action !== defaultControl.action) return true;
+    for (const defaultControl of DEFAULT_KEYBOARD_SETTINGS.controls) {
+      const currentControl = currentByAction.get(defaultControl.action);
+
+      if (!currentControl) return true;
       if (currentControl.enabled !== defaultControl.enabled) return true;
       if (!keyBindingsEqual(currentControl.binding, defaultControl.binding)) return true;
     }

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -1,7 +1,3 @@
-/**
- * UI components for keyboard settings configuration
- */
-
 import {
   KeyBinding,
   KeyboardSettings,
@@ -19,9 +15,6 @@ interface KeyBindingEditorCallbacks {
   onCancel?: () => void;
 }
 
-/**
- * Creates an interactive key binding editor that captures key presses
- */
 export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: KeyBindingEditorCallbacks): HTMLElement {
   const container = document.createElement('div');
   container.className = 'bes-key-binding-editor-container';
@@ -51,14 +44,12 @@ export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: Ke
     e.preventDefault();
     e.stopPropagation();
 
-    // Cancel on Escape
     if (e.key === 'Escape') {
       stopRecording();
       callbacks.onCancel?.();
       return;
     }
 
-    // Ignore modifier-only presses
     if (['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) {
       return;
     }
@@ -71,7 +62,6 @@ export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: Ke
       meta: e.metaKey
     };
 
-    // Update current binding
     Object.assign(currentBinding, newBinding);
     stopRecording();
     callbacks.onBindingChange(newBinding);
@@ -84,7 +74,6 @@ export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: Ke
     }
   });
 
-  // Add global keydown listener when recording
   document.addEventListener('keydown', handleKeyDown);
 
   container.appendChild(display);
@@ -92,9 +81,6 @@ export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: Ke
   return container;
 }
 
-/**
- * Creates a number input for step size settings
- */
 function createStepSizeInput(
   label: string,
   currentValue: number,
@@ -131,9 +117,6 @@ function createStepSizeInput(
   return container;
 }
 
-/**
- * Creates a row for a single keyboard control setting
- */
 function createKeyboardControlRow(
   control: KeyboardControlSetting,
   settings: KeyboardSettings,
@@ -142,12 +125,10 @@ function createKeyboardControlRow(
   const row = document.createElement('div');
   row.className = 'bes-keyboard-control-row';
 
-  // Description
   const description = document.createElement('span');
   description.className = 'bes-keyboard-control-description';
   description.textContent = ACTION_DESCRIPTIONS[control.action];
 
-  // Enable/disable checkbox
   const enableCheckbox = document.createElement('input');
   enableCheckbox.type = 'checkbox';
   enableCheckbox.checked = control.enabled;
@@ -159,12 +140,10 @@ function createKeyboardControlRow(
     onUpdate({ ...settings });
   });
 
-  // Key binding editor
   const editor = createKeyBindingEditor(control.binding, {
     onBindingChange: newBinding => {
       control.binding = newBinding;
 
-      // Check for conflicts
       const conflicts = settings.controls.filter(
         c => c.enabled && c.action !== control.action && keyBindingsEqual(c.binding, newBinding)
       );
@@ -223,12 +202,8 @@ function createCategorySection(
   return section;
 }
 
-// Track collapsed state across section recreations
 let keyboardSectionCollapsed = true;
 
-/**
- * Creates the complete keyboard settings section for the drawer
- */
 export function createKeyboardSettingsSection(
   settings: KeyboardSettings,
   onUpdate: (updatedSettings: KeyboardSettings) => void
@@ -236,10 +211,8 @@ export function createKeyboardSettingsSection(
   const section = document.createElement('div');
   section.className = 'bes-drawer-section bes-keyboard-section';
 
-  // Create a ref to hold the update visibility function
   let updateResetVisibilityFn: (() => void) | null = null;
 
-  // Wrap onUpdate to also update reset button visibility
   const wrappedOnUpdate = (updatedSettings: KeyboardSettings) => {
     onUpdate(updatedSettings);
     if (updateResetVisibilityFn) {
@@ -274,7 +247,6 @@ export function createKeyboardSettingsSection(
 
   content.appendChild(description);
 
-  // Restore previous collapsed state
   if (keyboardSectionCollapsed) {
     content.classList.add('collapsed');
   }
@@ -290,7 +262,6 @@ export function createKeyboardSettingsSection(
 
   section.appendChild(header);
 
-  // Group controls by category
   const controlsByCategory = new Map<ActionCategory, KeyboardControlSetting[]>();
 
   settings.controls.forEach(control => {
@@ -301,7 +272,6 @@ export function createKeyboardSettingsSection(
     controlsByCategory.get(category)!.push(control);
   });
 
-  // Create sections for each category
   const categoryOrder = [ActionCategory.PLAYBACK, ActionCategory.SEEKING, ActionCategory.VOLUME];
 
   categoryOrder.forEach(category => {
@@ -312,7 +282,6 @@ export function createKeyboardSettingsSection(
     }
   });
 
-  // Step size settings
   const stepSizesSection = document.createElement('div');
   stepSizesSection.className = 'bes-keyboard-step-sizes';
 
@@ -322,14 +291,12 @@ export function createKeyboardSettingsSection(
 
   stepSizesSection.appendChild(stepSizesHeader);
 
-  // Seek step size
   const seekStepInput = createStepSizeInput('Seek step (seconds):', settings.seekStepSize, 1, 1, value => {
     settings.seekStepSize = value;
     wrappedOnUpdate({ ...settings });
   });
   stepSizesSection.appendChild(seekStepInput);
 
-  // Large seek step size
   const largeSeekStepInput = createStepSizeInput(
     'Large seek step (seconds):',
     settings.largeSeekStepSize,
@@ -342,7 +309,6 @@ export function createKeyboardSettingsSection(
   );
   stepSizesSection.appendChild(largeSeekStepInput);
 
-  // Volume step
   const volumeStepInput = createStepSizeInput('Volume step:', settings.volumeStep, 0.01, 0.01, value => {
     settings.volumeStep = value;
     wrappedOnUpdate({ ...settings });
@@ -351,14 +317,11 @@ export function createKeyboardSettingsSection(
 
   content.appendChild(stepSizesSection);
 
-  // Helper function to check if settings are modified
   const areSettingsModified = (current: KeyboardSettings): boolean => {
-    // Check if step sizes are different
     if (current.seekStepSize !== DEFAULT_KEYBOARD_SETTINGS.seekStepSize) return true;
     if (current.largeSeekStepSize !== DEFAULT_KEYBOARD_SETTINGS.largeSeekStepSize) return true;
     if (current.volumeStep !== DEFAULT_KEYBOARD_SETTINGS.volumeStep) return true;
 
-    // Check if controls are different
     if (current.controls.length !== DEFAULT_KEYBOARD_SETTINGS.controls.length) return true;
 
     for (let i = 0; i < current.controls.length; i++) {
@@ -373,11 +336,9 @@ export function createKeyboardSettingsSection(
     return false;
   };
 
-  // Reset button and confirmation
   const resetContainer = document.createElement('div');
   resetContainer.className = 'bes-keyboard-reset-container';
 
-  // Update reset container visibility based on whether settings are modified
   const updateResetVisibility = () => {
     if (areSettingsModified(settings)) {
       resetContainer.style.display = 'block';
@@ -386,7 +347,6 @@ export function createKeyboardSettingsSection(
     }
   };
 
-  // Assign to ref so wrappedOnUpdate can call it
   updateResetVisibilityFn = updateResetVisibility;
 
   const resetButton = document.createElement('button');
@@ -423,10 +383,8 @@ export function createKeyboardSettingsSection(
   });
 
   confirmButton.addEventListener('click', () => {
-    // This will be handled by sending a message to the backend
     const resetEvent = new CustomEvent('bes-reset-keyboard-settings');
     document.dispatchEvent(resetEvent);
-    // Hide confirmation and show reset button again
     confirmationUI.style.display = 'none';
     resetButton.style.display = 'block';
   });
@@ -442,7 +400,6 @@ export function createKeyboardSettingsSection(
 
   section.appendChild(content);
 
-  // Set initial visibility of reset button
   updateResetVisibility();
 
   return section;

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -25,6 +25,7 @@ export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: Ke
   display.title = 'Click to change key binding';
 
   let isRecording = false;
+  const abortController = new AbortController();
 
   const startRecording = () => {
     isRecording = true;
@@ -74,7 +75,15 @@ export function createKeyBindingEditor(currentBinding: KeyBinding, callbacks: Ke
     }
   });
 
-  document.addEventListener('keydown', handleKeyDown);
+  document.addEventListener('keydown', handleKeyDown, { signal: abortController.signal });
+
+  const observer = new MutationObserver(() => {
+    if (!document.body.contains(container)) {
+      abortController.abort();
+      observer.disconnect();
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
 
   container.appendChild(display);
 

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -225,6 +225,9 @@ function createCategorySection(
   return section;
 }
 
+// Track collapsed state across section recreations
+let keyboardSectionCollapsed = true;
+
 /**
  * Creates the complete keyboard settings section for the drawer
  */
@@ -243,7 +246,7 @@ export function createKeyboardSettingsSection(
 
   const arrow = document.createElement('span');
   arrow.className = 'bes-keyboard-section-arrow';
-  arrow.textContent = '▶';
+  arrow.textContent = keyboardSectionCollapsed ? '▶' : '▼';
 
   const titleText = document.createElement('span');
   titleText.textContent = 'Keyboard Controls';
@@ -262,14 +265,15 @@ export function createKeyboardSettingsSection(
 
   content.appendChild(description);
 
-  // Toggle collapse/expand
-  let isCollapsed = true;
-  content.classList.add('collapsed');
+  // Restore previous collapsed state
+  if (keyboardSectionCollapsed) {
+    content.classList.add('collapsed');
+  }
 
   const toggleCollapse = () => {
-    isCollapsed = !isCollapsed;
-    content.classList.toggle('collapsed', isCollapsed);
-    arrow.textContent = isCollapsed ? '▶' : '▼';
+    keyboardSectionCollapsed = !keyboardSectionCollapsed;
+    content.classList.toggle('collapsed', keyboardSectionCollapsed);
+    arrow.textContent = keyboardSectionCollapsed ? '▶' : '▼';
   };
 
   title.addEventListener('click', toggleCollapse);

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -99,7 +99,6 @@ function createStepSizeInput(
   label: string,
   currentValue: number,
   min: number,
-  max: number,
   step: number,
   onChange: (value: number) => void
 ): HTMLElement {
@@ -114,13 +113,12 @@ function createStepSizeInput(
   input.type = 'number';
   input.className = 'bes-keyboard-step-input';
   input.min = min.toString();
-  input.max = max.toString();
   input.step = step.toString();
   input.value = currentValue.toString();
 
   input.addEventListener('change', () => {
     const value = parseFloat(input.value);
-    if (!isNaN(value) && value >= min && value <= max) {
+    if (!isNaN(value) && value >= min) {
       onChange(value);
     } else {
       input.value = currentValue.toString();
@@ -314,7 +312,7 @@ export function createKeyboardSettingsSection(
   stepSizesSection.appendChild(stepSizesHeader);
 
   // Seek step size
-  const seekStepInput = createStepSizeInput('Seek step (seconds):', settings.seekStepSize, 1, 60, 1, value => {
+  const seekStepInput = createStepSizeInput('Seek step (seconds):', settings.seekStepSize, 1, 1, value => {
     settings.seekStepSize = value;
     onUpdate({ ...settings });
   });
@@ -325,7 +323,6 @@ export function createKeyboardSettingsSection(
     'Large seek step (seconds):',
     settings.largeSeekStepSize,
     1,
-    120,
     1,
     value => {
       settings.largeSeekStepSize = value;
@@ -335,7 +332,7 @@ export function createKeyboardSettingsSection(
   stepSizesSection.appendChild(largeSeekStepInput);
 
   // Volume step
-  const volumeStepInput = createStepSizeInput('Volume step:', settings.volumeStep, 0.01, 0.5, 0.01, value => {
+  const volumeStepInput = createStepSizeInput('Volume step:', settings.volumeStep, 0.01, 0.01, value => {
     settings.volumeStep = value;
     onUpdate({ ...settings });
   });

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -235,15 +235,47 @@ export function createKeyboardSettingsSection(
   const section = document.createElement('div');
   section.className = 'bes-drawer-section bes-keyboard-section';
 
+  const header = document.createElement('div');
+  header.className = 'bes-keyboard-section-header';
+
   const title = document.createElement('h3');
-  title.textContent = 'Keyboard Controls';
+  title.className = 'bes-keyboard-section-title';
+
+  const arrow = document.createElement('span');
+  arrow.className = 'bes-keyboard-section-arrow';
+  arrow.textContent = '▶';
+
+  const titleText = document.createElement('span');
+  titleText.textContent = 'Keyboard Controls';
+
+  title.appendChild(arrow);
+  title.appendChild(titleText);
+
+  header.appendChild(title);
+
+  const content = document.createElement('div');
+  content.className = 'bes-keyboard-section-content';
 
   const description = document.createElement('p');
   description.className = 'bes-keyboard-description';
   description.textContent = 'Customize keyboard shortcuts for player controls. Click a key binding to change it.';
 
-  section.appendChild(title);
-  section.appendChild(description);
+  content.appendChild(description);
+
+  // Toggle collapse/expand
+  let isCollapsed = true;
+  content.classList.add('collapsed');
+
+  const toggleCollapse = () => {
+    isCollapsed = !isCollapsed;
+    content.classList.toggle('collapsed', isCollapsed);
+    arrow.textContent = isCollapsed ? '▶' : '▼';
+  };
+
+  title.addEventListener('click', toggleCollapse);
+  title.style.cursor = 'pointer';
+
+  section.appendChild(header);
 
   // Group controls by category
   const controlsByCategory = new Map<ActionCategory, KeyboardControlSetting[]>();
@@ -263,7 +295,7 @@ export function createKeyboardSettingsSection(
     const controls = controlsByCategory.get(category);
     if (controls && controls.length > 0) {
       const categorySection = createCategorySection(category, controls, settings, onUpdate);
-      section.appendChild(categorySection);
+      content.appendChild(categorySection);
     }
   });
 
@@ -305,7 +337,7 @@ export function createKeyboardSettingsSection(
   });
   stepSizesSection.appendChild(volumeStepInput);
 
-  section.appendChild(stepSizesSection);
+  content.appendChild(stepSizesSection);
 
   // Reset button
   const resetButton = document.createElement('button');
@@ -320,7 +352,9 @@ export function createKeyboardSettingsSection(
     }
   });
 
-  section.appendChild(resetButton);
+  content.appendChild(resetButton);
+
+  section.appendChild(content);
 
   return section;
 }

--- a/src/components/keyboardSettings.ts
+++ b/src/components/keyboardSettings.ts
@@ -4,14 +4,14 @@
 
 import {
   KeyBinding,
-  KeyboardAction,
   KeyboardSettings,
   KeyboardControlSetting,
   ACTION_DESCRIPTIONS,
   ACTION_CATEGORIES,
   ActionCategory,
   keyBindingToString,
-  keyBindingsEqual
+  keyBindingsEqual,
+  DEFAULT_KEYBOARD_SETTINGS
 } from '../types/keyboard.js';
 
 interface KeyBindingEditorCallbacks {
@@ -236,6 +236,17 @@ export function createKeyboardSettingsSection(
   const section = document.createElement('div');
   section.className = 'bes-drawer-section bes-keyboard-section';
 
+  // Create a ref to hold the update visibility function
+  let updateResetVisibilityFn: (() => void) | null = null;
+
+  // Wrap onUpdate to also update reset button visibility
+  const wrappedOnUpdate = (updatedSettings: KeyboardSettings) => {
+    onUpdate(updatedSettings);
+    if (updateResetVisibilityFn) {
+      updateResetVisibilityFn();
+    }
+  };
+
   const header = document.createElement('div');
   header.className = 'bes-keyboard-section-header';
 
@@ -296,7 +307,7 @@ export function createKeyboardSettingsSection(
   categoryOrder.forEach(category => {
     const controls = controlsByCategory.get(category);
     if (controls && controls.length > 0) {
-      const categorySection = createCategorySection(category, controls, settings, onUpdate);
+      const categorySection = createCategorySection(category, controls, settings, wrappedOnUpdate);
       content.appendChild(categorySection);
     }
   });
@@ -314,7 +325,7 @@ export function createKeyboardSettingsSection(
   // Seek step size
   const seekStepInput = createStepSizeInput('Seek step (seconds):', settings.seekStepSize, 1, 1, value => {
     settings.seekStepSize = value;
-    onUpdate({ ...settings });
+    wrappedOnUpdate({ ...settings });
   });
   stepSizesSection.appendChild(seekStepInput);
 
@@ -326,7 +337,7 @@ export function createKeyboardSettingsSection(
     1,
     value => {
       settings.largeSeekStepSize = value;
-      onUpdate({ ...settings });
+      wrappedOnUpdate({ ...settings });
     }
   );
   stepSizesSection.appendChild(largeSeekStepInput);
@@ -334,15 +345,49 @@ export function createKeyboardSettingsSection(
   // Volume step
   const volumeStepInput = createStepSizeInput('Volume step:', settings.volumeStep, 0.01, 0.01, value => {
     settings.volumeStep = value;
-    onUpdate({ ...settings });
+    wrappedOnUpdate({ ...settings });
   });
   stepSizesSection.appendChild(volumeStepInput);
 
   content.appendChild(stepSizesSection);
 
+  // Helper function to check if settings are modified
+  const areSettingsModified = (current: KeyboardSettings): boolean => {
+    // Check if step sizes are different
+    if (current.seekStepSize !== DEFAULT_KEYBOARD_SETTINGS.seekStepSize) return true;
+    if (current.largeSeekStepSize !== DEFAULT_KEYBOARD_SETTINGS.largeSeekStepSize) return true;
+    if (current.volumeStep !== DEFAULT_KEYBOARD_SETTINGS.volumeStep) return true;
+
+    // Check if controls are different
+    if (current.controls.length !== DEFAULT_KEYBOARD_SETTINGS.controls.length) return true;
+
+    for (let i = 0; i < current.controls.length; i++) {
+      const currentControl = current.controls[i];
+      const defaultControl = DEFAULT_KEYBOARD_SETTINGS.controls[i];
+
+      if (currentControl.action !== defaultControl.action) return true;
+      if (currentControl.enabled !== defaultControl.enabled) return true;
+      if (!keyBindingsEqual(currentControl.binding, defaultControl.binding)) return true;
+    }
+
+    return false;
+  };
+
   // Reset button and confirmation
   const resetContainer = document.createElement('div');
   resetContainer.className = 'bes-keyboard-reset-container';
+
+  // Update reset container visibility based on whether settings are modified
+  const updateResetVisibility = () => {
+    if (areSettingsModified(settings)) {
+      resetContainer.style.display = 'block';
+    } else {
+      resetContainer.style.display = 'none';
+    }
+  };
+
+  // Assign to ref so wrappedOnUpdate can call it
+  updateResetVisibilityFn = updateResetVisibility;
 
   const resetButton = document.createElement('button');
   resetButton.className = 'bes-drawer-button bes-keyboard-reset-button';
@@ -396,6 +441,9 @@ export function createKeyboardSettingsSection(
   content.appendChild(resetContainer);
 
   section.appendChild(content);
+
+  // Set initial visibility of reset button
+  updateResetVisibility();
 
   return section;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,16 +81,18 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
       config_port.postMessage({ updateKeyboardSettings: updatedSettings });
     });
 
-    if (settingsSection.parentNode) {
-      const nextSibling = settingsSection.nextSibling;
-      if (nextSibling) {
-        settingsSection.parentNode.insertBefore(keyboardSection, nextSibling);
-      } else {
-        settingsSection.parentNode.appendChild(keyboardSection);
-      }
-    } else {
+    if (!settingsSection.parentNode) {
       content.appendChild(keyboardSection);
+      return;
     }
+
+    const nextSibling = settingsSection.nextSibling;
+    if (nextSibling) {
+      settingsSection.parentNode.insertBefore(keyboardSection, nextSibling);
+      return;
+    }
+
+    settingsSection.parentNode.appendChild(keyboardSection);
   };
 
   document.addEventListener('bes-reset-keyboard-settings', () => {
@@ -104,11 +106,7 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
     }
 
     if (msg.config && msg.config.keyboardSettings) {
-      if (!keyboardSection) {
-        initKeyboardSection(msg.config.keyboardSettings);
-      } else {
-        initKeyboardSection(msg.config.keyboardSettings);
-      }
+      initKeyboardSection(msg.config.keyboardSettings);
     }
 
     if (msg.keyboardSettingsError) {
@@ -229,10 +227,8 @@ const main = async (): Promise<void> => {
     } catch (e: any) {
       if (e.message?.includes('Error in invocation of runtime.connect in main.js')) {
         log.error(e);
-        throw e;
-      } else {
-        throw e;
       }
+      throw e;
     }
   })();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import { initPlayer } from './player';
 import { initAudioFeatures } from './audioFeatures';
 import { initCart } from './pages/cart';
 import { initHideUnhide } from './pages/hide_unhide_collection';
+import { createKeyboardSettingsSection } from './components/keyboardSettings.js';
+import { KeyboardSettings } from './types/keyboard.js';
 
 const log = createLogger();
 
@@ -67,9 +69,54 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
   settingsSection.appendChild(settingsTitle);
   settingsSection.appendChild(waveformSettingRow);
 
+  // Keyboard settings section
+  let keyboardSection: HTMLElement | null = null;
+
+  const initKeyboardSection = (settings: KeyboardSettings) => {
+    // Remove old section if it exists
+    if (keyboardSection) {
+      keyboardSection.remove();
+    }
+
+    // Create new keyboard section
+    keyboardSection = createKeyboardSettingsSection(settings, updatedSettings => {
+      log.info('Keyboard settings updated');
+      config_port.postMessage({ updateKeyboardSettings: updatedSettings });
+    });
+
+    // Insert after settings section
+    if (findMusicSection.parentNode) {
+      findMusicSection.parentNode.insertBefore(keyboardSection, findMusicSection);
+    } else {
+      content.appendChild(keyboardSection);
+    }
+  };
+
+  // Listen for reset event from keyboard settings UI
+  document.addEventListener('bes-reset-keyboard-settings', () => {
+    log.info('Resetting keyboard settings');
+    config_port.postMessage({ resetKeyboardSettings: true });
+  });
+
   config_port.onMessage.addListener((msg: any) => {
     if (msg.config && typeof msg.config.displayWaveform === 'boolean') {
       waveformToggle.checked = msg.config.displayWaveform;
+    }
+
+    // Update keyboard settings
+    if (msg.config && msg.config.keyboardSettings) {
+      if (!keyboardSection) {
+        initKeyboardSection(msg.config.keyboardSettings);
+      } else {
+        // Re-initialize section if settings changed externally
+        initKeyboardSection(msg.config.keyboardSettings);
+      }
+    }
+
+    // Handle keyboard settings errors
+    if (msg.keyboardSettingsError) {
+      log.error(`Keyboard settings error: ${msg.keyboardSettingsError.join(', ')}`);
+      alert(`Keyboard settings error: ${msg.keyboardSettingsError.join(', ')}`);
     }
   });
 
@@ -196,7 +243,29 @@ const main = async (): Promise<void> => {
 
   const checkIsPageWithPlayer: Element | null = document.querySelector('div.inline_player');
   if (checkIsPageWithPlayer && window.location.href !== 'https://bandcamp.com/') {
-    await initPlayer();
+    // Get keyboard settings from config before initializing player
+    let keyboardSettings: KeyboardSettings | undefined;
+
+    const getConfigPromise = new Promise<void>(resolve => {
+      const listener = (msg: any) => {
+        if (msg.config && msg.config.keyboardSettings) {
+          keyboardSettings = msg.config.keyboardSettings;
+          config_port.onMessage.removeListener(listener);
+          resolve();
+        }
+      };
+      config_port.onMessage.addListener(listener);
+      config_port.postMessage({ requestConfig: {} });
+
+      // Timeout after 1 second and use defaults
+      setTimeout(() => {
+        config_port.onMessage.removeListener(listener);
+        resolve();
+      }, 1000);
+    });
+
+    await getConfigPromise;
+    await initPlayer(keyboardSettings);
     initAudioFeatures(config_port);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,22 +69,18 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
   settingsSection.appendChild(settingsTitle);
   settingsSection.appendChild(waveformSettingRow);
 
-  // Keyboard settings section
   let keyboardSection: HTMLElement | null = null;
 
   const initKeyboardSection = (settings: KeyboardSettings) => {
-    // Remove old section if it exists
     if (keyboardSection) {
       keyboardSection.remove();
     }
 
-    // Create new keyboard section
     keyboardSection = createKeyboardSettingsSection(settings, updatedSettings => {
       log.info('Keyboard settings updated');
       config_port.postMessage({ updateKeyboardSettings: updatedSettings });
     });
 
-    // Insert after settings section
     if (settingsSection.parentNode) {
       const nextSibling = settingsSection.nextSibling;
       if (nextSibling) {
@@ -97,7 +93,6 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
     }
   };
 
-  // Listen for reset event from keyboard settings UI
   document.addEventListener('bes-reset-keyboard-settings', () => {
     log.info('Resetting keyboard settings');
     config_port.postMessage({ resetKeyboardSettings: true });
@@ -108,17 +103,14 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
       waveformToggle.checked = msg.config.displayWaveform;
     }
 
-    // Update keyboard settings
     if (msg.config && msg.config.keyboardSettings) {
       if (!keyboardSection) {
         initKeyboardSection(msg.config.keyboardSettings);
       } else {
-        // Re-initialize section if settings changed externally
         initKeyboardSection(msg.config.keyboardSettings);
       }
     }
 
-    // Handle keyboard settings errors
     if (msg.keyboardSettingsError) {
       log.error(`Keyboard settings error: ${msg.keyboardSettingsError.join(', ')}`);
       alert(`Keyboard settings error: ${msg.keyboardSettingsError.join(', ')}`);
@@ -248,7 +240,6 @@ const main = async (): Promise<void> => {
 
   const checkIsPageWithPlayer: Element | null = document.querySelector('div.inline_player');
   if (checkIsPageWithPlayer && window.location.href !== 'https://bandcamp.com/') {
-    // Get keyboard settings from config before initializing player
     let keyboardSettings: KeyboardSettings | undefined;
 
     const getConfigPromise = new Promise<void>(resolve => {
@@ -262,7 +253,6 @@ const main = async (): Promise<void> => {
       config_port.onMessage.addListener(listener);
       config_port.postMessage({ requestConfig: {} });
 
-      // Timeout after 1 second and use defaults
       setTimeout(() => {
         config_port.onMessage.removeListener(listener);
         resolve();
@@ -272,7 +262,6 @@ const main = async (): Promise<void> => {
     await getConfigPromise;
     await initPlayer(keyboardSettings);
 
-    // Listen for keyboard settings updates and update handlers dynamically
     config_port.onMessage.addListener((msg: any) => {
       if (msg.config && msg.config.keyboardSettings) {
         log.info('Keyboard settings changed, updating handlers');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { createLogger } from './logger';
 import { initLabelView } from './label_view';
 import { initDownload } from './pages/download';
-import { initPlayer } from './player';
+import { initPlayer, updateKeyboardHandlers } from './player';
 import { initAudioFeatures } from './audioFeatures';
 import { initCart } from './pages/cart';
 import { initHideUnhide } from './pages/hide_unhide_collection';
@@ -271,6 +271,15 @@ const main = async (): Promise<void> => {
 
     await getConfigPromise;
     await initPlayer(keyboardSettings);
+
+    // Listen for keyboard settings updates and update handlers dynamically
+    config_port.onMessage.addListener((msg: any) => {
+      if (msg.config && msg.config.keyboardSettings) {
+        log.info('Keyboard settings changed, updating handlers');
+        updateKeyboardHandlers(msg.config.keyboardSettings);
+      }
+    });
+
     initAudioFeatures(config_port);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
   const settingsSection = document.createElement('div');
   settingsSection.className = 'bes-drawer-section';
 
-  const settingsTitle = document.createElement('h3');
+  const settingsTitle = document.createElement('h2');
   settingsTitle.textContent = 'Settings';
 
   const waveformSettingRow = document.createElement('div');
@@ -85,8 +85,13 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
     });
 
     // Insert after settings section
-    if (findMusicSection.parentNode) {
-      findMusicSection.parentNode.insertBefore(keyboardSection, findMusicSection);
+    if (settingsSection.parentNode) {
+      const nextSibling = settingsSection.nextSibling;
+      if (nextSibling) {
+        settingsSection.parentNode.insertBefore(keyboardSection, nextSibling);
+      } else {
+        settingsSection.parentNode.appendChild(keyboardSection);
+      }
     } else {
       content.appendChild(keyboardSection);
     }
@@ -160,8 +165,8 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
   findMusicSection.appendChild(findMusicDesc);
   findMusicSection.appendChild(findMusicButton);
 
-  content.appendChild(settingsSection);
   content.appendChild(findMusicSection);
+  content.appendChild(settingsSection);
 
   drawer.appendChild(header);
   drawer.appendChild(content);

--- a/src/player.ts
+++ b/src/player.ts
@@ -4,6 +4,7 @@ import { CURRENCY_MINIMUMS, getTralbumDetails, addAlbumToCart } from './bclient'
 import { createInputButtonPair } from './components/buttons.js';
 import { createShoppingCartItem } from './components/shoppingCart.js';
 import { createPlusSvgIcon } from './components/svgIcons';
+import { KeyboardSettings, KeyboardAction, DEFAULT_KEYBOARD_SETTINGS, keyBindingToString } from './types/keyboard.js';
 
 interface KeyCombo {
   key: string;
@@ -17,81 +18,111 @@ interface KeyHandlers {
   [key: string]: () => void;
 }
 
-const SEEK_STEP_SIZE = 10;
-const LARGE_SEEK_STEP_SIZE = 30;
-const VOLUME_STEP = 0.05;
-const DEFAULT_KEY_HANDLERS: KeyHandlers = {
-  ' ': () => {
-    const playButton = document.querySelector('div.playbutton');
-    if (!playButton) return;
-    (playButton as HTMLElement).click();
-  },
-  p: () => {
-    const playButton = document.querySelector('div.playbutton');
-    if (!playButton) return;
-    (playButton as HTMLElement).click();
-  },
-  ArrowUp: () => {
-    const prevButton = document.querySelector('div.prevbutton');
-    if (!prevButton) return;
-    (prevButton as HTMLElement).click();
-  },
-  ArrowDown: () => {
-    const nextButton = document.querySelector('div.nextbutton');
-    if (!nextButton) return;
-    (nextButton as HTMLElement).click();
-  },
-  ArrowRight: () => {
-    const audio = document.querySelector('audio') as HTMLAudioElement;
-    if (!audio) return;
-
-    audio.currentTime = audio.currentTime + SEEK_STEP_SIZE;
-  },
-  ArrowLeft: () => {
-    const audio = document.querySelector('audio') as HTMLAudioElement;
-    if (!audio) return;
-
-    audio.currentTime = audio.currentTime - SEEK_STEP_SIZE;
-  },
-  'Shift+ArrowLeft': () => {
-    const audio = document.querySelector('audio') as HTMLAudioElement;
-    if (!audio) return;
-
-    audio.currentTime = audio.currentTime - LARGE_SEEK_STEP_SIZE;
-  },
-  'Shift+ArrowRight': () => {
-    const audio = document.querySelector('audio') as HTMLAudioElement;
-    if (!audio) return;
-
-    audio.currentTime = audio.currentTime + LARGE_SEEK_STEP_SIZE;
-  },
-  'Shift+ArrowUp': () => {
-    const input = document.querySelector('input.volume') as HTMLInputElement;
-    if (!input) return;
-
-    const currentVolume = parseFloat(input.value);
-    const newVolume = currentVolume + VOLUME_STEP;
-    input.value = (newVolume > 1.0 ? 1.0 : newVolume).toString();
-
-    const event = new Event('input');
-    input.dispatchEvent(event);
-  },
-  'Shift+ArrowDown': () => {
-    const input = document.querySelector('input.volume') as HTMLInputElement;
-    if (!input) return;
-
-    const currentVolume = parseFloat(input.value);
-    const newVolume = currentVolume - VOLUME_STEP;
-    input.value = (newVolume < 0.0 ? 0.0 : newVolume).toString();
-
-    const event = new Event('input');
-    input.dispatchEvent(event);
-  }
-};
-
 function keyComboToString(combo: KeyCombo): string {
   const { key, alt = false, ctrl = false, shift = false, meta = false } = combo;
   return `${alt ? 'Alt+' : ''}${ctrl ? 'Ctrl+' : ''}${shift ? 'Shift+' : ''}${meta ? 'Meta+' : ''}${key}`;
+}
+
+/**
+ * Build key handlers from keyboard settings
+ */
+export function buildKeyHandlersFromSettings(settings: KeyboardSettings): KeyHandlers {
+  const handlers: KeyHandlers = {};
+
+  settings.controls.forEach(control => {
+    if (!control.enabled) return;
+
+    const bindingKey = keyBindingToString(control.binding);
+
+    switch (control.action) {
+      case KeyboardAction.PLAY_PAUSE:
+      case KeyboardAction.PLAY_PAUSE_ALT:
+        handlers[bindingKey] = () => {
+          const playButton = document.querySelector('div.playbutton');
+          if (!playButton) return;
+          (playButton as HTMLElement).click();
+        };
+        break;
+
+      case KeyboardAction.PREV_TRACK:
+        handlers[bindingKey] = () => {
+          const prevButton = document.querySelector('div.prevbutton');
+          if (!prevButton) return;
+          (prevButton as HTMLElement).click();
+        };
+        break;
+
+      case KeyboardAction.NEXT_TRACK:
+        handlers[bindingKey] = () => {
+          const nextButton = document.querySelector('div.nextbutton');
+          if (!nextButton) return;
+          (nextButton as HTMLElement).click();
+        };
+        break;
+
+      case KeyboardAction.SEEK_FORWARD:
+        handlers[bindingKey] = () => {
+          const audio = document.querySelector('audio') as HTMLAudioElement;
+          if (!audio) return;
+          audio.currentTime = audio.currentTime + settings.seekStepSize;
+        };
+        break;
+
+      case KeyboardAction.SEEK_BACKWARD:
+        handlers[bindingKey] = () => {
+          const audio = document.querySelector('audio') as HTMLAudioElement;
+          if (!audio) return;
+          audio.currentTime = audio.currentTime - settings.seekStepSize;
+        };
+        break;
+
+      case KeyboardAction.SEEK_FORWARD_LARGE:
+        handlers[bindingKey] = () => {
+          const audio = document.querySelector('audio') as HTMLAudioElement;
+          if (!audio) return;
+          audio.currentTime = audio.currentTime + settings.largeSeekStepSize;
+        };
+        break;
+
+      case KeyboardAction.SEEK_BACKWARD_LARGE:
+        handlers[bindingKey] = () => {
+          const audio = document.querySelector('audio') as HTMLAudioElement;
+          if (!audio) return;
+          audio.currentTime = audio.currentTime - settings.largeSeekStepSize;
+        };
+        break;
+
+      case KeyboardAction.VOLUME_UP:
+        handlers[bindingKey] = () => {
+          const input = document.querySelector('input.volume') as HTMLInputElement;
+          if (!input) return;
+
+          const currentVolume = parseFloat(input.value);
+          const newVolume = currentVolume + settings.volumeStep;
+          input.value = (newVolume > 1.0 ? 1.0 : newVolume).toString();
+
+          const event = new Event('input');
+          input.dispatchEvent(event);
+        };
+        break;
+
+      case KeyboardAction.VOLUME_DOWN:
+        handlers[bindingKey] = () => {
+          const input = document.querySelector('input.volume') as HTMLInputElement;
+          if (!input) return;
+
+          const currentVolume = parseFloat(input.value);
+          const newVolume = currentVolume - settings.volumeStep;
+          input.value = (newVolume < 0.0 ? 0.0 : newVolume).toString();
+
+          const event = new Event('input');
+          input.dispatchEvent(event);
+        };
+        break;
+    }
+  });
+
+  return handlers;
 }
 
 export function keydownCallback(
@@ -191,9 +222,12 @@ export function createOneClickBuyButton(
   return pair;
 }
 
-export async function initPlayer(): Promise<void> {
+export async function initPlayer(keyboardSettings?: KeyboardSettings): Promise<void> {
   const log = new Logger();
-  const keyHandlers = DEFAULT_KEY_HANDLERS;
+
+  // Use provided settings or fall back to defaults
+  const settings = keyboardSettings || DEFAULT_KEYBOARD_SETTINGS;
+  const keyHandlers = buildKeyHandlersFromSettings(settings);
   const preventDefault = true;
 
   log.info('Starting BES Player');

--- a/src/player.ts
+++ b/src/player.ts
@@ -20,16 +20,10 @@ interface KeyHandlers {
 
 function keyComboToString(combo: KeyCombo): string {
   const { key, alt = false, ctrl = false, shift = false, meta = false } = combo;
-
-  // Special case for space key to match keyBindingToString in keyboard.ts
   const keyDisplay = key === ' ' ? 'Space' : key;
-
   return `${alt ? 'Alt+' : ''}${ctrl ? 'Ctrl+' : ''}${shift ? 'Shift+' : ''}${meta ? 'Meta+' : ''}${keyDisplay}`;
 }
 
-/**
- * Build key handlers from keyboard settings
- */
 export function buildKeyHandlersFromSettings(settings: KeyboardSettings): KeyHandlers {
   const handlers: KeyHandlers = {};
 
@@ -226,37 +220,29 @@ export function createOneClickBuyButton(
   return pair;
 }
 
-// Global handler object that can be updated dynamically
 let activeKeyHandlers: KeyHandlers = {};
 
-/**
- * Update keyboard handlers with new settings
- */
 export function updateKeyboardHandlers(settings: KeyboardSettings): void {
   const log = new Logger();
   log.info('Updating keyboard handlers');
 
-  // Clear existing handlers
   Object.keys(activeKeyHandlers).forEach(key => delete activeKeyHandlers[key]);
-
-  // Build new handlers
   const newHandlers = buildKeyHandlersFromSettings(settings);
-
-  // Copy new handlers into the active object
   Object.assign(activeKeyHandlers, newHandlers);
 }
 
 export async function initPlayer(keyboardSettings?: KeyboardSettings): Promise<void> {
   const log = new Logger();
 
-  // Use provided settings or fall back to defaults
   const settings = keyboardSettings || DEFAULT_KEYBOARD_SETTINGS;
   activeKeyHandlers = buildKeyHandlersFromSettings(settings);
   const preventDefault = true;
 
   log.info('Starting BES Player');
 
-  document.addEventListener('keydown', (e: KeyboardEvent) => keydownCallback(e, activeKeyHandlers, preventDefault, log));
+  document.addEventListener('keydown', (e: KeyboardEvent) =>
+    keydownCallback(e, activeKeyHandlers, preventDefault, log)
+  );
 
   const progressBar = document.querySelector('.progbar') as HTMLElement;
   if (progressBar) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -226,17 +226,37 @@ export function createOneClickBuyButton(
   return pair;
 }
 
+// Global handler object that can be updated dynamically
+let activeKeyHandlers: KeyHandlers = {};
+
+/**
+ * Update keyboard handlers with new settings
+ */
+export function updateKeyboardHandlers(settings: KeyboardSettings): void {
+  const log = new Logger();
+  log.info('Updating keyboard handlers');
+
+  // Clear existing handlers
+  Object.keys(activeKeyHandlers).forEach(key => delete activeKeyHandlers[key]);
+
+  // Build new handlers
+  const newHandlers = buildKeyHandlersFromSettings(settings);
+
+  // Copy new handlers into the active object
+  Object.assign(activeKeyHandlers, newHandlers);
+}
+
 export async function initPlayer(keyboardSettings?: KeyboardSettings): Promise<void> {
   const log = new Logger();
 
   // Use provided settings or fall back to defaults
   const settings = keyboardSettings || DEFAULT_KEYBOARD_SETTINGS;
-  const keyHandlers = buildKeyHandlersFromSettings(settings);
+  activeKeyHandlers = buildKeyHandlersFromSettings(settings);
   const preventDefault = true;
 
   log.info('Starting BES Player');
 
-  document.addEventListener('keydown', (e: KeyboardEvent) => keydownCallback(e, keyHandlers, preventDefault, log));
+  document.addEventListener('keydown', (e: KeyboardEvent) => keydownCallback(e, activeKeyHandlers, preventDefault, log));
 
   const progressBar = document.querySelector('.progbar') as HTMLElement;
   if (progressBar) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -20,7 +20,11 @@ interface KeyHandlers {
 
 function keyComboToString(combo: KeyCombo): string {
   const { key, alt = false, ctrl = false, shift = false, meta = false } = combo;
-  return `${alt ? 'Alt+' : ''}${ctrl ? 'Ctrl+' : ''}${shift ? 'Shift+' : ''}${meta ? 'Meta+' : ''}${key}`;
+
+  // Special case for space key to match keyBindingToString in keyboard.ts
+  const keyDisplay = key === ' ' ? 'Space' : key;
+
+  return `${alt ? 'Alt+' : ''}${ctrl ? 'Ctrl+' : ''}${shift ? 'Shift+' : ''}${meta ? 'Meta+' : ''}${keyDisplay}`;
 }
 
 /**

--- a/src/types/keyboard.ts
+++ b/src/types/keyboard.ts
@@ -169,12 +169,12 @@ export function validateKeyboardSettings(settings: KeyboardSettings): string[] {
     }
   }
 
-  if (settings.seekStepSize <= 0 || settings.seekStepSize > 60) {
-    errors.push('Seek step size must be between 0 and 60 seconds');
+  if (settings.seekStepSize <= 0) {
+    errors.push('Seek step size must be greater than 0');
   }
 
-  if (settings.largeSeekStepSize <= 0 || settings.largeSeekStepSize > 300) {
-    errors.push('Large seek step size must be between 0 and 300 seconds');
+  if (settings.largeSeekStepSize <= 0) {
+    errors.push('Large seek step size must be greater than 0');
   }
 
   if (settings.volumeStep <= 0 || settings.volumeStep > 1) {

--- a/src/types/keyboard.ts
+++ b/src/types/keyboard.ts
@@ -1,10 +1,3 @@
-/**
- * Keyboard settings types for configurable keyboard controls
- */
-
-/**
- * Represents a key binding with optional modifiers
- */
 export interface KeyBinding {
   key: string;
   shift?: boolean;
@@ -13,12 +6,9 @@ export interface KeyBinding {
   meta?: boolean;
 }
 
-/**
- * Available keyboard actions
- */
 export enum KeyboardAction {
   PLAY_PAUSE = 'PLAY_PAUSE',
-  PLAY_PAUSE_ALT = 'PLAY_PAUSE_ALT', // Alternative binding (P key)
+  PLAY_PAUSE_ALT = 'PLAY_PAUSE_ALT',
   PREV_TRACK = 'PREV_TRACK',
   NEXT_TRACK = 'NEXT_TRACK',
   SEEK_FORWARD = 'SEEK_FORWARD',
@@ -29,9 +19,6 @@ export enum KeyboardAction {
   VOLUME_DOWN = 'VOLUME_DOWN'
 }
 
-/**
- * Human-readable descriptions for each action
- */
 export const ACTION_DESCRIPTIONS: Record<KeyboardAction, string> = {
   [KeyboardAction.PLAY_PAUSE]: 'Play/Pause',
   [KeyboardAction.PLAY_PAUSE_ALT]: 'Play/Pause (Alternative)',
@@ -45,18 +32,12 @@ export const ACTION_DESCRIPTIONS: Record<KeyboardAction, string> = {
   [KeyboardAction.VOLUME_DOWN]: 'Volume Down'
 };
 
-/**
- * Categories for grouping actions in the UI
- */
 export enum ActionCategory {
   PLAYBACK = 'Playback',
   SEEKING = 'Seeking',
   VOLUME = 'Volume'
 }
 
-/**
- * Mapping of actions to their categories
- */
 export const ACTION_CATEGORIES: Record<KeyboardAction, ActionCategory> = {
   [KeyboardAction.PLAY_PAUSE]: ActionCategory.PLAYBACK,
   [KeyboardAction.PLAY_PAUSE_ALT]: ActionCategory.PLAYBACK,
@@ -70,28 +51,19 @@ export const ACTION_CATEGORIES: Record<KeyboardAction, ActionCategory> = {
   [KeyboardAction.VOLUME_DOWN]: ActionCategory.VOLUME
 };
 
-/**
- * A single keyboard control setting
- */
 export interface KeyboardControlSetting {
   action: KeyboardAction;
   binding: KeyBinding;
   enabled: boolean;
 }
 
-/**
- * Complete keyboard settings including all controls and step sizes
- */
 export interface KeyboardSettings {
   controls: KeyboardControlSetting[];
-  seekStepSize: number; // seconds
-  largeSeekStepSize: number; // seconds
-  volumeStep: number; // 0.0 to 1.0
+  seekStepSize: number;
+  largeSeekStepSize: number;
+  volumeStep: number;
 }
 
-/**
- * Default keyboard settings matching the current hardcoded values
- */
 export const DEFAULT_KEYBOARD_SETTINGS: KeyboardSettings = {
   controls: [
     {
@@ -150,13 +122,9 @@ export const DEFAULT_KEYBOARD_SETTINGS: KeyboardSettings = {
   volumeStep: 0.05
 };
 
-/**
- * Convert a key binding to a string representation
- */
 export function keyBindingToString(binding: KeyBinding): string {
   const { key, alt = false, ctrl = false, shift = false, meta = false } = binding;
 
-  // Special case for space key
   const keyDisplay = key === ' ' ? 'Space' : key;
 
   const modifiers: string[] = [];
@@ -168,9 +136,6 @@ export function keyBindingToString(binding: KeyBinding): string {
   return modifiers.length > 0 ? `${modifiers.join('+')}+${keyDisplay}` : keyDisplay;
 }
 
-/**
- * Check if two key bindings are equal
- */
 export function keyBindingsEqual(a: KeyBinding, b: KeyBinding): boolean {
   return (
     a.key === b.key &&
@@ -181,14 +146,9 @@ export function keyBindingsEqual(a: KeyBinding, b: KeyBinding): boolean {
   );
 }
 
-/**
- * Validate keyboard settings
- * Returns an array of error messages, empty if valid
- */
 export function validateKeyboardSettings(settings: KeyboardSettings): string[] {
   const errors: string[] = [];
 
-  // Check for duplicate bindings
   const bindingMap = new Map<string, KeyboardAction[]>();
 
   for (const control of settings.controls) {
@@ -202,7 +162,6 @@ export function validateKeyboardSettings(settings: KeyboardSettings): string[] {
     bindingMap.get(bindingStr)!.push(control.action);
   }
 
-  // Report duplicates
   for (const [binding, actions] of bindingMap.entries()) {
     if (actions.length > 1) {
       const actionNames = actions.map(a => ACTION_DESCRIPTIONS[a]).join(', ');
@@ -210,7 +169,6 @@ export function validateKeyboardSettings(settings: KeyboardSettings): string[] {
     }
   }
 
-  // Validate step sizes
   if (settings.seekStepSize <= 0) {
     errors.push('Seek step size must be greater than 0');
   }

--- a/src/types/keyboard.ts
+++ b/src/types/keyboard.ts
@@ -1,0 +1,227 @@
+/**
+ * Keyboard settings types for configurable keyboard controls
+ */
+
+/**
+ * Represents a key binding with optional modifiers
+ */
+export interface KeyBinding {
+  key: string;
+  shift?: boolean;
+  alt?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+}
+
+/**
+ * Available keyboard actions
+ */
+export enum KeyboardAction {
+  PLAY_PAUSE = 'PLAY_PAUSE',
+  PLAY_PAUSE_ALT = 'PLAY_PAUSE_ALT', // Alternative binding (P key)
+  PREV_TRACK = 'PREV_TRACK',
+  NEXT_TRACK = 'NEXT_TRACK',
+  SEEK_FORWARD = 'SEEK_FORWARD',
+  SEEK_BACKWARD = 'SEEK_BACKWARD',
+  SEEK_FORWARD_LARGE = 'SEEK_FORWARD_LARGE',
+  SEEK_BACKWARD_LARGE = 'SEEK_BACKWARD_LARGE',
+  VOLUME_UP = 'VOLUME_UP',
+  VOLUME_DOWN = 'VOLUME_DOWN'
+}
+
+/**
+ * Human-readable descriptions for each action
+ */
+export const ACTION_DESCRIPTIONS: Record<KeyboardAction, string> = {
+  [KeyboardAction.PLAY_PAUSE]: 'Play/Pause',
+  [KeyboardAction.PLAY_PAUSE_ALT]: 'Play/Pause (Alternative)',
+  [KeyboardAction.PREV_TRACK]: 'Previous Track',
+  [KeyboardAction.NEXT_TRACK]: 'Next Track',
+  [KeyboardAction.SEEK_FORWARD]: 'Seek Forward',
+  [KeyboardAction.SEEK_BACKWARD]: 'Seek Backward',
+  [KeyboardAction.SEEK_FORWARD_LARGE]: 'Seek Forward (Large)',
+  [KeyboardAction.SEEK_BACKWARD_LARGE]: 'Seek Backward (Large)',
+  [KeyboardAction.VOLUME_UP]: 'Volume Up',
+  [KeyboardAction.VOLUME_DOWN]: 'Volume Down'
+};
+
+/**
+ * Categories for grouping actions in the UI
+ */
+export enum ActionCategory {
+  PLAYBACK = 'Playback',
+  SEEKING = 'Seeking',
+  VOLUME = 'Volume'
+}
+
+/**
+ * Mapping of actions to their categories
+ */
+export const ACTION_CATEGORIES: Record<KeyboardAction, ActionCategory> = {
+  [KeyboardAction.PLAY_PAUSE]: ActionCategory.PLAYBACK,
+  [KeyboardAction.PLAY_PAUSE_ALT]: ActionCategory.PLAYBACK,
+  [KeyboardAction.PREV_TRACK]: ActionCategory.PLAYBACK,
+  [KeyboardAction.NEXT_TRACK]: ActionCategory.PLAYBACK,
+  [KeyboardAction.SEEK_FORWARD]: ActionCategory.SEEKING,
+  [KeyboardAction.SEEK_BACKWARD]: ActionCategory.SEEKING,
+  [KeyboardAction.SEEK_FORWARD_LARGE]: ActionCategory.SEEKING,
+  [KeyboardAction.SEEK_BACKWARD_LARGE]: ActionCategory.SEEKING,
+  [KeyboardAction.VOLUME_UP]: ActionCategory.VOLUME,
+  [KeyboardAction.VOLUME_DOWN]: ActionCategory.VOLUME
+};
+
+/**
+ * A single keyboard control setting
+ */
+export interface KeyboardControlSetting {
+  action: KeyboardAction;
+  binding: KeyBinding;
+  enabled: boolean;
+}
+
+/**
+ * Complete keyboard settings including all controls and step sizes
+ */
+export interface KeyboardSettings {
+  controls: KeyboardControlSetting[];
+  seekStepSize: number; // seconds
+  largeSeekStepSize: number; // seconds
+  volumeStep: number; // 0.0 to 1.0
+}
+
+/**
+ * Default keyboard settings matching the current hardcoded values
+ */
+export const DEFAULT_KEYBOARD_SETTINGS: KeyboardSettings = {
+  controls: [
+    {
+      action: KeyboardAction.PLAY_PAUSE,
+      binding: { key: ' ' },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.PLAY_PAUSE_ALT,
+      binding: { key: 'p' },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.PREV_TRACK,
+      binding: { key: 'ArrowUp' },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.NEXT_TRACK,
+      binding: { key: 'ArrowDown' },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.SEEK_FORWARD,
+      binding: { key: 'ArrowRight' },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.SEEK_BACKWARD,
+      binding: { key: 'ArrowLeft' },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.SEEK_FORWARD_LARGE,
+      binding: { key: 'ArrowRight', shift: true },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.SEEK_BACKWARD_LARGE,
+      binding: { key: 'ArrowLeft', shift: true },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.VOLUME_UP,
+      binding: { key: 'ArrowUp', shift: true },
+      enabled: true
+    },
+    {
+      action: KeyboardAction.VOLUME_DOWN,
+      binding: { key: 'ArrowDown', shift: true },
+      enabled: true
+    }
+  ],
+  seekStepSize: 10,
+  largeSeekStepSize: 30,
+  volumeStep: 0.05
+};
+
+/**
+ * Convert a key binding to a string representation
+ */
+export function keyBindingToString(binding: KeyBinding): string {
+  const { key, alt = false, ctrl = false, shift = false, meta = false } = binding;
+
+  // Special case for space key
+  const keyDisplay = key === ' ' ? 'Space' : key;
+
+  const modifiers: string[] = [];
+  if (alt) modifiers.push('Alt');
+  if (ctrl) modifiers.push('Ctrl');
+  if (shift) modifiers.push('Shift');
+  if (meta) modifiers.push('Meta');
+
+  return modifiers.length > 0 ? `${modifiers.join('+')}+${keyDisplay}` : keyDisplay;
+}
+
+/**
+ * Check if two key bindings are equal
+ */
+export function keyBindingsEqual(a: KeyBinding, b: KeyBinding): boolean {
+  return (
+    a.key === b.key &&
+    (a.shift ?? false) === (b.shift ?? false) &&
+    (a.alt ?? false) === (b.alt ?? false) &&
+    (a.ctrl ?? false) === (b.ctrl ?? false) &&
+    (a.meta ?? false) === (b.meta ?? false)
+  );
+}
+
+/**
+ * Validate keyboard settings
+ * Returns an array of error messages, empty if valid
+ */
+export function validateKeyboardSettings(settings: KeyboardSettings): string[] {
+  const errors: string[] = [];
+
+  // Check for duplicate bindings
+  const bindingMap = new Map<string, KeyboardAction[]>();
+
+  for (const control of settings.controls) {
+    if (!control.enabled) continue;
+
+    const bindingStr = keyBindingToString(control.binding);
+
+    if (!bindingMap.has(bindingStr)) {
+      bindingMap.set(bindingStr, []);
+    }
+    bindingMap.get(bindingStr)!.push(control.action);
+  }
+
+  // Report duplicates
+  for (const [binding, actions] of bindingMap.entries()) {
+    if (actions.length > 1) {
+      const actionNames = actions.map(a => ACTION_DESCRIPTIONS[a]).join(', ');
+      errors.push(`Duplicate key binding "${binding}" used for: ${actionNames}`);
+    }
+  }
+
+  // Validate step sizes
+  if (settings.seekStepSize <= 0) {
+    errors.push('Seek step size must be greater than 0');
+  }
+
+  if (settings.largeSeekStepSize <= 0) {
+    errors.push('Large seek step size must be greater than 0');
+  }
+
+  if (settings.volumeStep <= 0 || settings.volumeStep > 1) {
+    errors.push('Volume step must be between 0 and 1');
+  }
+
+  return errors;
+}

--- a/src/types/keyboard.ts
+++ b/src/types/keyboard.ts
@@ -169,12 +169,12 @@ export function validateKeyboardSettings(settings: KeyboardSettings): string[] {
     }
   }
 
-  if (settings.seekStepSize <= 0) {
-    errors.push('Seek step size must be greater than 0');
+  if (settings.seekStepSize <= 0 || settings.seekStepSize > 60) {
+    errors.push('Seek step size must be between 0 and 60 seconds');
   }
 
-  if (settings.largeSeekStepSize <= 0) {
-    errors.push('Large seek step size must be greater than 0');
+  if (settings.largeSeekStepSize <= 0 || settings.largeSeekStepSize > 300) {
+    errors.push('Large seek step size must be between 0 and 300 seconds');
   }
 
   if (settings.volumeStep <= 0 || settings.volumeStep > 1) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -53,7 +53,7 @@ export function extractBandFollowInfo(): BandFollowInfo {
   try {
     const bandFollowInfo: BandFollowInfo = JSON.parse(data);
     return bandFollowInfo;
-  } catch (_error) {
+  } catch {
     return {};
   }
 }
@@ -84,7 +84,7 @@ export function extractFanTralbumData(): FanTralbumData {
     }
 
     return fan_tralbum_data;
-  } catch (_error) {
+  } catch {
     return defaultData;
   }
 }

--- a/test/config_backend.test.ts
+++ b/test/config_backend.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { updateKeyboardSettings, resetKeyboardSettings } from '../src/background/config_backend';
+import { DEFAULT_KEYBOARD_SETTINGS, KeyboardSettings, KeyboardAction } from '../src/types/keyboard';
+import Logger from '../src/logger';
 
 describe('Config Backend', () => {
   beforeEach(() => {
@@ -26,12 +29,144 @@ describe('Config Backend', () => {
 
   it('should manage configuration settings', () => {
     const mockConfig = { displayWaveform: true };
-    vi.mocked(globalThis.chrome.storage.local.get).mockImplementation((keys, callback) => {
+    vi.mocked(globalThis.chrome.storage.local.get).mockImplementation((_keys, callback) => {
       if (typeof callback === 'function') {
         callback(mockConfig);
       }
     });
 
     expect(globalThis.chrome.storage.local.get).toBeDefined();
+  });
+
+  describe('updateKeyboardSettings', () => {
+    it('should update keyboard settings in database', async () => {
+      const mockDb = {
+        get: vi.fn().mockResolvedValue({ displayWaveform: false }),
+        put: vi.fn().mockResolvedValue(undefined)
+      };
+      const mockPort = {
+        postMessage: vi.fn()
+      };
+      const mockLog = new Logger();
+
+      const customSettings: KeyboardSettings = {
+        ...DEFAULT_KEYBOARD_SETTINGS,
+        seekStepSize: 15
+      };
+
+      await updateKeyboardSettings(mockDb, customSettings, mockLog, mockPort as any);
+
+      expect(mockDb.get).toHaveBeenCalledWith('config', 'config');
+      expect(mockDb.put).toHaveBeenCalled();
+      expect(mockPort.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            keyboardSettings: customSettings
+          })
+        })
+      );
+    });
+
+    it('should reject invalid settings', async () => {
+      const mockDb = {
+        get: vi.fn(),
+        put: vi.fn()
+      };
+      const mockPort = {
+        postMessage: vi.fn()
+      };
+      const mockLog = new Logger();
+
+      const invalidSettings: KeyboardSettings = {
+        controls: [],
+        seekStepSize: 0,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      await updateKeyboardSettings(mockDb, invalidSettings, mockLog, mockPort as any);
+
+      expect(mockDb.put).not.toHaveBeenCalled();
+      expect(mockPort.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keyboardSettingsError: expect.arrayContaining([expect.stringContaining('Seek step size')])
+        })
+      );
+    });
+
+    it('should reject duplicate key bindings', async () => {
+      const mockDb = {
+        get: vi.fn(),
+        put: vi.fn()
+      };
+      const mockPort = {
+        postMessage: vi.fn()
+      };
+      const mockLog = new Logger();
+
+      const settingsWithDuplicates: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'p' },
+            enabled: true
+          },
+          {
+            action: KeyboardAction.NEXT_TRACK,
+            binding: { key: 'p' },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      await updateKeyboardSettings(mockDb, settingsWithDuplicates, mockLog, mockPort as any);
+
+      expect(mockDb.put).not.toHaveBeenCalled();
+      expect(mockPort.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keyboardSettingsError: expect.arrayContaining([expect.stringContaining('Duplicate key binding')])
+        })
+      );
+    });
+  });
+
+  describe('resetKeyboardSettings', () => {
+    it('should reset keyboard settings to defaults', async () => {
+      const mockDb = {
+        get: vi.fn().mockResolvedValue({ displayWaveform: true, keyboardSettings: { seekStepSize: 15 } }),
+        put: vi.fn().mockResolvedValue(undefined)
+      };
+      const mockPort = {
+        postMessage: vi.fn()
+      };
+      const mockLog = new Logger();
+
+      await resetKeyboardSettings(mockDb, mockLog, mockPort as any);
+
+      expect(mockDb.get).toHaveBeenCalledWith('config', 'config');
+      expect(mockDb.put).toHaveBeenCalled();
+      expect(mockPort.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            keyboardSettings: DEFAULT_KEYBOARD_SETTINGS
+          })
+        })
+      );
+    });
+
+    it('should work without a port', async () => {
+      const mockDb = {
+        get: vi.fn().mockResolvedValue({ displayWaveform: true }),
+        put: vi.fn().mockResolvedValue(undefined)
+      };
+      const mockLog = new Logger();
+
+      await resetKeyboardSettings(mockDb, mockLog);
+
+      expect(mockDb.put).toHaveBeenCalled();
+    });
   });
 });

--- a/test/keyboard.test.ts
+++ b/test/keyboard.test.ts
@@ -126,20 +126,7 @@ describe('Keyboard Settings', () => {
 
       const errors = validateKeyboardSettings(settings);
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0]).toContain('Seek step size must be between 0 and 60 seconds');
-    });
-
-    it('should reject seek step size above maximum', () => {
-      const settings: KeyboardSettings = {
-        controls: [],
-        seekStepSize: 100,
-        largeSeekStepSize: 30,
-        volumeStep: 0.05
-      };
-
-      const errors = validateKeyboardSettings(settings);
-      expect(errors.length).toBeGreaterThan(0);
-      expect(errors.some(e => e.includes('Seek step size must be between 0 and 60 seconds'))).toBe(true);
+      expect(errors[0]).toContain('Seek step size must be greater than 0');
     });
 
     it('should validate large seek step size', () => {
@@ -153,19 +140,6 @@ describe('Keyboard Settings', () => {
       const errors = validateKeyboardSettings(settings);
       expect(errors.length).toBeGreaterThan(0);
       expect(errors.some(e => e.includes('Large seek step size'))).toBe(true);
-    });
-
-    it('should reject large seek step size above maximum', () => {
-      const settings: KeyboardSettings = {
-        controls: [],
-        seekStepSize: 10,
-        largeSeekStepSize: 500,
-        volumeStep: 0.05
-      };
-
-      const errors = validateKeyboardSettings(settings);
-      expect(errors.length).toBeGreaterThan(0);
-      expect(errors.some(e => e.includes('Large seek step size must be between 0 and 300 seconds'))).toBe(true);
     });
 
     it('should validate volume step range', () => {

--- a/test/keyboard.test.ts
+++ b/test/keyboard.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import {
+  KeyBinding,
+  KeyboardAction,
+  KeyboardSettings,
+  DEFAULT_KEYBOARD_SETTINGS,
+  keyBindingToString,
+  keyBindingsEqual,
+  validateKeyboardSettings
+} from '../src/types/keyboard';
+
+describe('Keyboard Settings', () => {
+  describe('keyBindingToString', () => {
+    it('should convert simple key binding to string', () => {
+      const binding: KeyBinding = { key: 'p' };
+      expect(keyBindingToString(binding)).toBe('p');
+    });
+
+    it('should convert space key to "Space"', () => {
+      const binding: KeyBinding = { key: ' ' };
+      expect(keyBindingToString(binding)).toBe('Space');
+    });
+
+    it('should convert key binding with shift to string', () => {
+      const binding: KeyBinding = { key: 'ArrowRight', shift: true };
+      expect(keyBindingToString(binding)).toBe('Shift+ArrowRight');
+    });
+
+    it('should convert key binding with multiple modifiers to string', () => {
+      const binding: KeyBinding = { key: 'p', ctrl: true, shift: true };
+      expect(keyBindingToString(binding)).toBe('Ctrl+Shift+p');
+    });
+
+    it('should order modifiers correctly', () => {
+      const binding: KeyBinding = { key: 'a', meta: true, ctrl: true, alt: true, shift: true };
+      expect(keyBindingToString(binding)).toBe('Alt+Ctrl+Shift+Meta+a');
+    });
+  });
+
+  describe('keyBindingsEqual', () => {
+    it('should return true for identical bindings', () => {
+      const a: KeyBinding = { key: 'p', shift: true };
+      const b: KeyBinding = { key: 'p', shift: true };
+      expect(keyBindingsEqual(a, b)).toBe(true);
+    });
+
+    it('should return false for different keys', () => {
+      const a: KeyBinding = { key: 'p' };
+      const b: KeyBinding = { key: 'q' };
+      expect(keyBindingsEqual(a, b)).toBe(false);
+    });
+
+    it('should return false for different modifiers', () => {
+      const a: KeyBinding = { key: 'p', shift: true };
+      const b: KeyBinding = { key: 'p', ctrl: true };
+      expect(keyBindingsEqual(a, b)).toBe(false);
+    });
+
+    it('should handle undefined modifiers as false', () => {
+      const a: KeyBinding = { key: 'p' };
+      const b: KeyBinding = { key: 'p', shift: false };
+      expect(keyBindingsEqual(a, b)).toBe(true);
+    });
+  });
+
+  describe('validateKeyboardSettings', () => {
+    it('should validate default settings without errors', () => {
+      const errors = validateKeyboardSettings(DEFAULT_KEYBOARD_SETTINGS);
+      expect(errors).toEqual([]);
+    });
+
+    it('should detect duplicate key bindings', () => {
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'p' },
+            enabled: true
+          },
+          {
+            action: KeyboardAction.NEXT_TRACK,
+            binding: { key: 'p' },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0]).toContain('Duplicate key binding');
+    });
+
+    it('should not report duplicates for disabled controls', () => {
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'p' },
+            enabled: true
+          },
+          {
+            action: KeyboardAction.NEXT_TRACK,
+            binding: { key: 'p' },
+            enabled: false
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors).toEqual([]);
+    });
+
+    it('should validate seek step size', () => {
+      const settings: KeyboardSettings = {
+        controls: [],
+        seekStepSize: 0,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0]).toContain('Seek step size must be greater than 0');
+    });
+
+    it('should validate large seek step size', () => {
+      const settings: KeyboardSettings = {
+        controls: [],
+        seekStepSize: 10,
+        largeSeekStepSize: -5,
+        volumeStep: 0.05
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some(e => e.includes('Large seek step size'))).toBe(true);
+    });
+
+    it('should validate volume step range', () => {
+      const settings: KeyboardSettings = {
+        controls: [],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 1.5
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some(e => e.includes('Volume step'))).toBe(true);
+    });
+  });
+
+  describe('DEFAULT_KEYBOARD_SETTINGS', () => {
+    it('should have all required actions defined', () => {
+      const actions = DEFAULT_KEYBOARD_SETTINGS.controls.map(c => c.action);
+
+      expect(actions).toContain(KeyboardAction.PLAY_PAUSE);
+      expect(actions).toContain(KeyboardAction.PREV_TRACK);
+      expect(actions).toContain(KeyboardAction.NEXT_TRACK);
+      expect(actions).toContain(KeyboardAction.SEEK_FORWARD);
+      expect(actions).toContain(KeyboardAction.SEEK_BACKWARD);
+      expect(actions).toContain(KeyboardAction.VOLUME_UP);
+      expect(actions).toContain(KeyboardAction.VOLUME_DOWN);
+    });
+
+    it('should have all controls enabled by default', () => {
+      DEFAULT_KEYBOARD_SETTINGS.controls.forEach(control => {
+        expect(control.enabled).toBe(true);
+      });
+    });
+
+    it('should have reasonable default step sizes', () => {
+      expect(DEFAULT_KEYBOARD_SETTINGS.seekStepSize).toBe(10);
+      expect(DEFAULT_KEYBOARD_SETTINGS.largeSeekStepSize).toBe(30);
+      expect(DEFAULT_KEYBOARD_SETTINGS.volumeStep).toBe(0.05);
+    });
+
+    it('should not have duplicate key bindings', () => {
+      const errors = validateKeyboardSettings(DEFAULT_KEYBOARD_SETTINGS);
+      expect(errors).toEqual([]);
+    });
+  });
+});

--- a/test/keyboard.test.ts
+++ b/test/keyboard.test.ts
@@ -126,7 +126,20 @@ describe('Keyboard Settings', () => {
 
       const errors = validateKeyboardSettings(settings);
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0]).toContain('Seek step size must be greater than 0');
+      expect(errors[0]).toContain('Seek step size must be between 0 and 60 seconds');
+    });
+
+    it('should reject seek step size above maximum', () => {
+      const settings: KeyboardSettings = {
+        controls: [],
+        seekStepSize: 100,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some(e => e.includes('Seek step size must be between 0 and 60 seconds'))).toBe(true);
     });
 
     it('should validate large seek step size', () => {
@@ -140,6 +153,19 @@ describe('Keyboard Settings', () => {
       const errors = validateKeyboardSettings(settings);
       expect(errors.length).toBeGreaterThan(0);
       expect(errors.some(e => e.includes('Large seek step size'))).toBe(true);
+    });
+
+    it('should reject large seek step size above maximum', () => {
+      const settings: KeyboardSettings = {
+        controls: [],
+        seekStepSize: 10,
+        largeSeekStepSize: 500,
+        volumeStep: 0.05
+      };
+
+      const errors = validateKeyboardSettings(settings);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some(e => e.includes('Large seek step size must be between 0 and 300 seconds'))).toBe(true);
     });
 
     it('should validate volume step range', () => {

--- a/test/keyboardSettings.test.ts
+++ b/test/keyboardSettings.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createDomNodes, cleanupTestNodes } from './utils';
+import { createKeyboardSettingsSection, createKeyBindingEditor } from '../src/components/keyboardSettings';
+import { DEFAULT_KEYBOARD_SETTINGS } from '../src/types/keyboard';
+
+describe('Keyboard Settings Components', () => {
+  beforeEach(() => {
+    createDomNodes('<div id="test-container"></div>');
+  });
+
+  afterEach(() => {
+    cleanupTestNodes();
+  });
+
+  describe('createKeyboardSettingsSection', () => {
+    it('should create keyboard settings section', () => {
+      const onUpdate = vi.fn();
+      const section = createKeyboardSettingsSection(DEFAULT_KEYBOARD_SETTINGS, onUpdate);
+
+      expect(section).toBeDefined();
+      expect(section.className).toContain('bes-keyboard-section');
+    });
+
+    it('should create collapsible section that starts collapsed', () => {
+      const onUpdate = vi.fn();
+      const section = createKeyboardSettingsSection(DEFAULT_KEYBOARD_SETTINGS, onUpdate);
+
+      const content = section.querySelector('.bes-keyboard-section-content');
+      expect(content).toBeDefined();
+      expect(content?.classList.contains('collapsed')).toBe(true);
+    });
+
+    it('should have a clickable title for toggling', () => {
+      const onUpdate = vi.fn();
+      const section = createKeyboardSettingsSection(DEFAULT_KEYBOARD_SETTINGS, onUpdate);
+
+      const title = section.querySelector('.bes-keyboard-section-title');
+      expect(title).toBeDefined();
+    });
+
+    it('should show reset button only when settings are modified', () => {
+      const onUpdate = vi.fn();
+      const section = createKeyboardSettingsSection(DEFAULT_KEYBOARD_SETTINGS, onUpdate);
+
+      const resetContainer = section.querySelector('.bes-keyboard-reset-container');
+      expect(resetContainer).toBeDefined();
+      expect((resetContainer as HTMLElement).style.display).toBe('none');
+    });
+
+    it('should show reset button when settings differ from defaults', () => {
+      const onUpdate = vi.fn();
+      const modifiedSettings = {
+        ...DEFAULT_KEYBOARD_SETTINGS,
+        seekStepSize: 15
+      };
+      const section = createKeyboardSettingsSection(modifiedSettings, onUpdate);
+
+      const resetContainer = section.querySelector('.bes-keyboard-reset-container');
+      expect(resetContainer).toBeDefined();
+      expect((resetContainer as HTMLElement).style.display).toBe('block');
+    });
+
+    it('should create category sections for all control types', () => {
+      const onUpdate = vi.fn();
+      const section = createKeyboardSettingsSection(DEFAULT_KEYBOARD_SETTINGS, onUpdate);
+
+      const categories = section.querySelectorAll('.bes-keyboard-category-section');
+      expect(categories.length).toBeGreaterThan(0);
+    });
+
+    it('should create step size inputs', () => {
+      const onUpdate = vi.fn();
+      const section = createKeyboardSettingsSection(DEFAULT_KEYBOARD_SETTINGS, onUpdate);
+
+      const stepSizesSection = section.querySelector('.bes-keyboard-step-sizes');
+      expect(stepSizesSection).toBeDefined();
+
+      const inputs = stepSizesSection?.querySelectorAll('.bes-keyboard-step-input');
+      expect(inputs?.length).toBe(3);
+    });
+
+    it('should show reset confirmation UI when reset button is clicked', () => {
+      const onUpdate = vi.fn();
+      const modifiedSettings = {
+        ...DEFAULT_KEYBOARD_SETTINGS,
+        seekStepSize: 15
+      };
+      const section = createKeyboardSettingsSection(modifiedSettings, onUpdate);
+
+      const resetButton = section.querySelector('.bes-keyboard-reset-button') as HTMLButtonElement;
+      expect(resetButton).toBeDefined();
+
+      resetButton.click();
+
+      const confirmationUI = section.querySelector('.bes-keyboard-reset-confirmation') as HTMLElement;
+      expect(confirmationUI.style.display).toBe('block');
+    });
+  });
+
+  describe('createKeyBindingEditor', () => {
+    it('should create key binding editor', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      expect(editor).toBeDefined();
+      expect(editor.className).toContain('bes-key-binding-editor-container');
+    });
+
+    it('should display current binding', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      const display = editor.querySelector('.bes-key-binding-display');
+      expect(display?.textContent).toBe('p');
+    });
+
+    it('should display space key as "Space"', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: ' ' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      const display = editor.querySelector('.bes-key-binding-display');
+      expect(display?.textContent).toBe('Space');
+    });
+
+    it('should enter recording mode when clicked', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      const display = editor.querySelector('.bes-key-binding-display') as HTMLButtonElement;
+      display.click();
+
+      expect(display.classList.contains('recording')).toBe(true);
+      expect(display.textContent).toBe('Press any key...');
+    });
+
+    it('should update binding on key press when recording', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      const display = editor.querySelector('.bes-key-binding-display') as HTMLButtonElement;
+      display.click();
+
+      const keyEvent = new KeyboardEvent('keydown', {
+        key: 'x',
+        bubbles: true
+      });
+      document.dispatchEvent(keyEvent);
+
+      expect(onBindingChange).toHaveBeenCalledWith(expect.objectContaining({ key: 'x' }));
+    });
+
+    it('should ignore modifier-only key presses', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      const display = editor.querySelector('.bes-key-binding-display') as HTMLButtonElement;
+      display.click();
+
+      const keyEvent = new KeyboardEvent('keydown', {
+        key: 'Shift',
+        bubbles: true
+      });
+      document.dispatchEvent(keyEvent);
+
+      expect(onBindingChange).not.toHaveBeenCalled();
+    });
+
+    it('should cancel recording on Escape', () => {
+      const onCancel = vi.fn();
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange, onCancel });
+
+      const display = editor.querySelector('.bes-key-binding-display') as HTMLButtonElement;
+      display.click();
+
+      const keyEvent = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true
+      });
+      document.dispatchEvent(keyEvent);
+
+      expect(onCancel).toHaveBeenCalled();
+      expect(display.classList.contains('recording')).toBe(false);
+    });
+
+    it('should capture modifier keys', () => {
+      const onBindingChange = vi.fn();
+      const binding = { key: 'p' };
+      const editor = createKeyBindingEditor(binding, { onBindingChange });
+
+      const display = editor.querySelector('.bes-key-binding-display') as HTMLButtonElement;
+      display.click();
+
+      const keyEvent = new KeyboardEvent('keydown', {
+        key: 'x',
+        shiftKey: true,
+        ctrlKey: true,
+        bubbles: true
+      });
+      document.dispatchEvent(keyEvent);
+
+      expect(onBindingChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'x',
+          shift: true,
+          ctrl: true
+        })
+      );
+    });
+  });
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -104,13 +104,16 @@ describe('BES Drawer', () => {
   });
 
   it('should create settings section with waveform toggle', () => {
-    const settingsSection = document.querySelector('.bes-drawer-section h3');
-    if (!settingsSection) return;
+    const sections = document.querySelectorAll('.bes-drawer-section');
+    if (sections.length < 2) return;
+
+    const settingsSection = sections[1];
+    const settingsTitle = settingsSection.querySelector('h2');
 
     const waveformToggle = document.getElementById('bes-waveform-toggle') as HTMLInputElement;
     const waveformLabel = document.querySelector('label[for="bes-waveform-toggle"]');
 
-    expect(settingsSection.textContent).toContain('Settings');
+    expect(settingsTitle?.textContent).toContain('Settings');
     expect(waveformToggle).toBeTruthy();
     expect(waveformToggle?.type).toBe('checkbox');
     expect(waveformToggle?.className).toBe('waveform');
@@ -122,7 +125,7 @@ describe('BES Drawer', () => {
     const sections = document.querySelectorAll('.bes-drawer-section');
     if (sections.length < 2) return;
 
-    const findMusicSection = sections[1];
+    const findMusicSection = sections[0];
     const title = findMusicSection.querySelector('h3');
     const description = findMusicSection.querySelector('p');
     const button = findMusicSection.querySelector('.bes-drawer-button');

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -90,12 +90,12 @@ describe('BES Drawer', () => {
 
   it('should create drawer with header, content, and sections', () => {
     const drawer = document.querySelector('.bes-drawer');
-    if (!drawer) return; // Skip if drawer not created yet
+    expect(drawer).toBeTruthy();
 
-    const header = drawer.querySelector('.bes-drawer-header');
+    const header = drawer!.querySelector('.bes-drawer-header');
     const title = header?.querySelector('h2');
     const closeButton = header?.querySelector('.bes-drawer-close');
-    const content = drawer.querySelector('.bes-drawer-content');
+    const content = drawer!.querySelector('.bes-drawer-content');
 
     expect(header).toBeTruthy();
     expect(title?.textContent).toBe('Bandcamp Enhancement Suite');
@@ -105,7 +105,7 @@ describe('BES Drawer', () => {
 
   it('should create settings section with waveform toggle', () => {
     const sections = document.querySelectorAll('.bes-drawer-section');
-    if (sections.length < 2) return;
+    expect(sections.length).toBeGreaterThanOrEqual(2);
 
     const settingsSection = sections[1];
     const settingsTitle = settingsSection.querySelector('h2');
@@ -123,7 +123,7 @@ describe('BES Drawer', () => {
 
   it('should create FindMusic section with button', () => {
     const sections = document.querySelectorAll('.bes-drawer-section');
-    if (sections.length < 2) return;
+    expect(sections.length).toBeGreaterThanOrEqual(2);
 
     const findMusicSection = sections[0];
     const title = findMusicSection.querySelector('h3');
@@ -137,12 +137,12 @@ describe('BES Drawer', () => {
 
   it('should have floating button with BES icon', () => {
     const button = document.querySelector('.findmusic-floating-button');
-    if (!button) return;
+    expect(button).toBeTruthy();
 
-    const icon = button.querySelector('img.findmusic-button-icon') as HTMLImageElement;
+    const icon = button!.querySelector('img.findmusic-button-icon') as HTMLImageElement;
 
-    expect(button.getAttribute('title')).toBe('BES Settings');
-    expect(button.getAttribute('aria-label')).toBe('Toggle Bandcamp Enhancement Suite Settings');
+    expect(button!.getAttribute('title')).toBe('BES Settings');
+    expect(button!.getAttribute('aria-label')).toBe('Toggle Bandcamp Enhancement Suite Settings');
     expect(icon).toBeTruthy();
     expect(icon.src).toContain('icons/icon48.png');
   });
@@ -152,20 +152,20 @@ describe('BES Drawer', () => {
     const drawer = document.querySelector('.bes-drawer');
     const overlay = document.querySelector('.bes-drawer-overlay');
 
-    if (!button || !drawer || !overlay) return;
+    expect(button).toBeTruthy();
+    expect(drawer).toBeTruthy();
+    expect(overlay).toBeTruthy();
 
-    // Open drawer
     button.click();
     await vi.waitFor(() => {
-      expect(drawer.classList.contains('open')).toBe(true);
-      expect(overlay.classList.contains('open')).toBe(true);
+      expect(drawer!.classList.contains('open')).toBe(true);
+      expect(overlay!.classList.contains('open')).toBe(true);
     });
 
-    // Close drawer
     button.click();
     await vi.waitFor(() => {
-      expect(drawer.classList.contains('open')).toBe(false);
-      expect(overlay.classList.contains('open')).toBe(false);
+      expect(drawer!.classList.contains('open')).toBe(false);
+      expect(overlay!.classList.contains('open')).toBe(false);
     });
   });
 
@@ -174,17 +174,17 @@ describe('BES Drawer', () => {
     const drawer = document.querySelector('.bes-drawer');
     const closeButton = drawer?.querySelector('.bes-drawer-close') as HTMLElement;
 
-    if (!button || !drawer || !closeButton) return;
+    expect(button).toBeTruthy();
+    expect(drawer).toBeTruthy();
+    expect(closeButton).toBeTruthy();
 
-    // Open drawer first
     button.click();
     await vi.waitFor(() => {
-      expect(drawer.classList.contains('open')).toBe(true);
+      expect(drawer!.classList.contains('open')).toBe(true);
     });
 
-    // Click close button
     closeButton.click();
-    expect(drawer.classList.contains('open')).toBe(false);
+    expect(drawer!.classList.contains('open')).toBe(false);
   });
 
   it('should close drawer when overlay is clicked', async () => {
@@ -192,24 +192,23 @@ describe('BES Drawer', () => {
     const drawer = document.querySelector('.bes-drawer');
     const overlay = document.querySelector('.bes-drawer-overlay') as HTMLElement;
 
-    if (!button || !drawer || !overlay) return;
+    expect(button).toBeTruthy();
+    expect(drawer).toBeTruthy();
+    expect(overlay).toBeTruthy();
 
-    // Open drawer first
     button.click();
     await vi.waitFor(() => {
-      expect(drawer.classList.contains('open')).toBe(true);
+      expect(drawer!.classList.contains('open')).toBe(true);
     });
 
-    // Click overlay
     overlay.click();
-    expect(drawer.classList.contains('open')).toBe(false);
+    expect(drawer!.classList.contains('open')).toBe(false);
   });
 
   it('should send waveform toggle message when toggle is changed', () => {
     const toggle = document.getElementById('bes-waveform-toggle') as HTMLInputElement;
-    if (!toggle) return;
+    expect(toggle).toBeTruthy();
 
-    // Simulate toggle change
     toggle.checked = true;
     toggle.dispatchEvent(new Event('change'));
 
@@ -228,9 +227,8 @@ describe('BES Drawer', () => {
 
   it('should update button text based on permission status', async () => {
     const findMusicButton = document.querySelector('.bes-drawer-button') as HTMLElement;
-    if (!findMusicButton) return;
+    expect(findMusicButton).toBeTruthy();
 
-    // Initial text should be set
     expect(findMusicButton.textContent).toMatch(/Enable FindMusic.club Integration|Log in to FindMusic.club/);
   });
 
@@ -239,22 +237,22 @@ describe('BES Drawer', () => {
     const drawer = document.querySelector('.bes-drawer');
     const findMusicButton = document.querySelector('.bes-drawer-button') as HTMLElement;
 
-    if (!openButton || !drawer || !findMusicButton) return;
+    expect(openButton).toBeTruthy();
+    expect(drawer).toBeTruthy();
+    expect(findMusicButton).toBeTruthy();
 
-    // Open drawer first
     openButton.click();
     await vi.waitFor(() => {
-      expect(drawer.classList.contains('open')).toBe(true);
+      expect(drawer!.classList.contains('open')).toBe(true);
     });
 
-    // Click FindMusic button
     findMusicButton.click();
-    expect(drawer.classList.contains('open')).toBe(false);
+    expect(drawer!.classList.contains('open')).toBe(false);
   });
 
   it('should send openFindMusic message when button is clicked', () => {
     const findMusicButton = document.querySelector('.bes-drawer-button') as HTMLElement;
-    if (!findMusicButton) return;
+    expect(findMusicButton).toBeTruthy();
 
     mockRuntimeSendMessage.mockClear();
     findMusicButton.click();

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -15,7 +15,8 @@ import {
   keydownCallback,
   volumeSliderCallback,
   initPlayer,
-  buildKeyHandlersFromSettings
+  buildKeyHandlersFromSettings,
+  updateKeyboardHandlers
 } from '../src/player';
 import Logger from '../src/logger';
 import { KeyboardSettings, KeyboardAction, DEFAULT_KEYBOARD_SETTINGS } from '../src/types/keyboard';
@@ -188,6 +189,40 @@ describe('Player', () => {
       const handlers = buildKeyHandlersFromSettings(settings);
       expect(handlers['Shift+ArrowRight']).toBeDefined();
       expect(typeof handlers['Shift+ArrowRight']).toBe('function');
+    });
+  });
+
+  describe('updateKeyboardHandlers', () => {
+    it('should update handlers with new settings', () => {
+      const initialSettings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'p' },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const updatedSettings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'x' },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      // This test verifies that updateKeyboardHandlers doesn't throw
+      expect(() => updateKeyboardHandlers(initialSettings)).not.toThrow();
+      expect(() => updateKeyboardHandlers(updatedSettings)).not.toThrow();
     });
   });
 });

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -10,8 +10,15 @@ vi.mock('../src/logger', () => ({
   }
 }));
 
-import { createVolumeSlider, keydownCallback, volumeSliderCallback, initPlayer } from '../src/player';
+import {
+  createVolumeSlider,
+  keydownCallback,
+  volumeSliderCallback,
+  initPlayer,
+  buildKeyHandlersFromSettings
+} from '../src/player';
 import Logger from '../src/logger';
+import { KeyboardSettings, KeyboardAction, DEFAULT_KEYBOARD_SETTINGS } from '../src/types/keyboard';
 
 describe('Player', () => {
   beforeEach(() => {
@@ -70,5 +77,117 @@ describe('Player', () => {
 
     expect(() => keydownCallback(mockKeyEvent, mockKeyHandlers, false, mockLogger)).not.toThrow();
     expect(mockKeyHandlers['p']).toHaveBeenCalled();
+  });
+
+  describe('buildKeyHandlersFromSettings', () => {
+    it('should build handlers from default settings', () => {
+      const handlers = buildKeyHandlersFromSettings(DEFAULT_KEYBOARD_SETTINGS);
+      expect(handlers).toBeDefined();
+      expect(Object.keys(handlers).length).toBeGreaterThan(0);
+    });
+
+    it('should create handler for play/pause action', () => {
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'p' },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const handlers = buildKeyHandlersFromSettings(settings);
+      expect(handlers['p']).toBeDefined();
+      expect(typeof handlers['p']).toBe('function');
+    });
+
+    it('should not create handler for disabled actions', () => {
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.PLAY_PAUSE,
+            binding: { key: 'p' },
+            enabled: false
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const handlers = buildKeyHandlersFromSettings(settings);
+      expect(handlers['p']).toBeUndefined();
+    });
+
+    it('should use custom seek step sizes', () => {
+      const audio = document.querySelector('audio') as HTMLAudioElement;
+      audio.currentTime = 0;
+
+      const customSeekStep = 15;
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.SEEK_FORWARD,
+            binding: { key: 'ArrowRight' },
+            enabled: true
+          }
+        ],
+        seekStepSize: customSeekStep,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const handlers = buildKeyHandlersFromSettings(settings);
+      handlers['ArrowRight']();
+
+      expect(audio.currentTime).toBe(customSeekStep);
+    });
+
+    it('should use custom volume step', () => {
+      const volumeInput = document.querySelector('input.volume') as HTMLInputElement;
+      volumeInput.value = '0.5';
+
+      const customVolumeStep = 0.1;
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.VOLUME_UP,
+            binding: { key: 'ArrowUp', shift: true },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: customVolumeStep
+      };
+
+      const handlers = buildKeyHandlersFromSettings(settings);
+      handlers['Shift+ArrowUp']();
+
+      expect(parseFloat(volumeInput.value)).toBe(0.6);
+    });
+
+    it('should handle modifier keys in bindings', () => {
+      const settings: KeyboardSettings = {
+        controls: [
+          {
+            action: KeyboardAction.SEEK_FORWARD_LARGE,
+            binding: { key: 'ArrowRight', shift: true },
+            enabled: true
+          }
+        ],
+        seekStepSize: 10,
+        largeSeekStepSize: 30,
+        volumeStep: 0.05
+      };
+
+      const handlers = buildKeyHandlersFromSettings(settings);
+      expect(handlers['Shift+ArrowRight']).toBeDefined();
+      expect(typeof handlers['Shift+ArrowRight']).toBe('function');
+    });
   });
 });

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -220,7 +220,6 @@ describe('Player', () => {
         volumeStep: 0.05
       };
 
-      // This test verifies that updateKeyboardHandlers doesn't throw
       expect(() => updateKeyboardHandlers(initialSettings)).not.toThrow();
       expect(() => updateKeyboardHandlers(updatedSettings)).not.toThrow();
     });


### PR DESCRIPTION
## Summary

Add user-editable keyboard controls for the Bandcamp player, allowing users to customize keyboard shortcuts and step sizes without page refresh.

## Features Added

### Keyboard Settings UI
- Collapsible keyboard controls section in settings drawer (collapsed by default)
- Enable/disable individual keyboard shortcuts
- Click-to-record interface for rebinding keys
- Support for modifier keys (Shift, Alt, Ctrl, Meta)
- Real-time conflict detection with visual warnings
- Grouped controls by category (Playback, Seeking, Volume)
- Adjustable step sizes for seek and volume controls
- Reset to defaults with inline confirmation dialog
- Settings persist to IndexedDB and apply without page refresh

### Default Keyboard Shortcuts
- **Space** / **p**: Play/Pause
- **↑** / **↓**: Previous/Next Track
- **←** / **→**: Seek Backward/Forward (10s)
- **Shift+←** / **Shift+→**: Large Seek (30s)
- **Shift+↑** / **Shift+↓**: Volume Up/Down

### Technical Changes
- New keyboard settings type system with validation
- Backend validation for duplicate bindings and invalid values
- Dynamic handler updates via message passing
- Event listener cleanup to prevent memory leaks
- Settings comparison by action key (order-independent)

## Testing
- 51 new tests across keyboard types, UI components, and backend
- All 300 tests passing

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>