### PR TITLE
Fix incomplete zip downloads by correcting CSS selector mismatch

### DIFF
--- a/src/background/download_backend.ts
+++ b/src/background/download_backend.ts
@@ -42,8 +42,12 @@ async function handleDownloadZip(
   partNumber?: number,
   totalParts?: number
 ): Promise<void> {
-  const partInfo = totalParts && totalParts > 1 ? ` (part ${partNumber} of ${totalParts})` : '';
-  log.info(`Starting background download for ${urls.length} files${partInfo}`);
+  const isMultiPart = totalParts && totalParts > 1;
+  if (isMultiPart) {
+    log.info(`Starting background download for ${urls.length} files (part ${partNumber} of ${totalParts})`);
+  } else {
+    log.info(`Starting background download for ${urls.length} files`);
+  }
 
   const files: { name: string; input: Uint8Array }[] = [];
   let completed = 0;
@@ -68,9 +72,7 @@ async function handleDownloadZip(
       }
 
       const filename = getFilenameFromResponse(response, url);
-      if (!filename) {
-        throw new Error(`Unable to determine filename for ${url}`);
-      }
+      if (!filename) throw new Error(`Unable to determine filename for ${url}`);
 
       const arrayBuffer = await response.arrayBuffer();
       log.info(`Downloaded ${filename}: ${arrayBuffer.byteLength} bytes`);
@@ -102,7 +104,6 @@ async function handleDownloadZip(
   for (let i = 0; i < urls.length; i += BATCH_SIZE) {
     const batch = urls.slice(i, i + BATCH_SIZE);
     const batchPromises = batch.map((url, batchIndex) => downloadFile(url, i + batchIndex));
-
     await Promise.all(batchPromises);
   }
 
@@ -130,38 +131,43 @@ async function handleDownloadZip(
     const blob = await downloadZip(files).blob();
     log.info(`Zip blob created, size: ${blob.size} bytes`);
 
-    const date = dateString();
-    const baseFilename = `bandcamp_${date}`;
-    const filename = totalParts && totalParts > 1 ? `${baseFilename}_part${partNumber}.zip` : `${baseFilename}.zip`;
-
-    log.info('Preparing to send zip data to frontend in chunks...');
+    const filename = (() => {
+      const baseFilename = `bandcamp_${dateString()}`;
+      return isMultiPart ? `${baseFilename}_part${partNumber}.zip` : `${baseFilename}.zip`;
+    })();
 
     const arrayBuffer = await blob.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
 
-    const oneMBChunk = 1024 * 1024;
-    const chunkSize = oneMBChunk;
-    const totalChunks = Math.ceil(uint8Array.length / chunkSize);
+    const { totalChunks, chunks } = (() => {
+      const CHUNK_SIZE = 1024 * 1024;
+      const count = Math.ceil(uint8Array.length / CHUNK_SIZE);
 
-    log.info(`Sending ${blob.size} bytes in ${totalChunks} chunks`);
+      log.info(`Sending ${blob.size} bytes in ${count} chunks`);
 
-    for (let i = 0; i < totalChunks; i++) {
-      const start = i * chunkSize;
-      const end = Math.min(start + chunkSize, uint8Array.length);
-      const chunk = uint8Array.slice(start, end);
+      const result: string[] = [];
+      for (let i = 0; i < count; i++) {
+        const start = i * CHUNK_SIZE;
+        const end = Math.min(start + CHUNK_SIZE, uint8Array.length);
+        const chunk = uint8Array.slice(start, end);
 
-      let binaryString = '';
-      for (let j = 0; j < chunk.length; j++) {
-        binaryString += String.fromCharCode(chunk[j]);
+        let binaryString = '';
+        for (let j = 0; j < chunk.length; j++) {
+          binaryString += String.fromCharCode(chunk[j]);
+        }
+        result.push(btoa(binaryString));
       }
-      const base64Chunk = btoa(binaryString);
 
+      return { totalChunks: count, chunks: result };
+    })();
+
+    for (let i = 0; i < chunks.length; i++) {
       port.postMessage({
         type: 'zipChunk',
         chunkIndex: i,
-        totalChunks: totalChunks,
-        data: base64Chunk,
-        filename: filename
+        totalChunks,
+        data: chunks[i],
+        filename
       } as ZipChunk);
 
       log.info(`Sent chunk ${i + 1}/${totalChunks}`);
@@ -172,7 +178,7 @@ async function handleDownloadZip(
     port.postMessage({
       type: 'downloadComplete',
       success: true,
-      filename: filename,
+      filename,
       message:
         failed === 0
           ? `Successfully downloaded ${completed} files as ${filename}`
@@ -194,31 +200,24 @@ function getFilenameFromResponse(response: Response, url: string): string | null
 
     if (!contentDisposition) {
       const urlObj = new URL(url);
-      const urlPathname = urlObj.pathname;
-      const filenameFromUrl = urlPathname.split('/').pop();
-
+      const filenameFromUrl = urlObj.pathname.split('/').pop();
       if (!filenameFromUrl) return null;
 
-      if (filenameFromUrl.includes('.')) return filenameFromUrl;
-
-      return `${filenameFromUrl}.flac`;
+      return filenameFromUrl.includes('.') ? filenameFromUrl : `${filenameFromUrl}.flac`;
     }
 
     const headerFilenamePattern = /filename\*?=['"]?([^'";]+)['"]?/i;
     const filenameMatch = contentDisposition.match(headerFilenamePattern);
-
     if (!filenameMatch || !filenameMatch[1]) return null;
 
     let extractedFilename = filenameMatch[1];
 
-    const isRfc5987Encoded = extractedFilename.includes("UTF-8''");
-    if (isRfc5987Encoded) {
+    if (extractedFilename.includes("UTF-8''")) {
       const encodedPart = extractedFilename.split("UTF-8''")[1];
       extractedFilename = decodeURIComponent(encodedPart);
     }
 
-    const hasFileExtension = extractedFilename.includes('.');
-    if (!hasFileExtension) {
+    if (!extractedFilename.includes('.')) {
       extractedFilename += '.flac';
     }
 

--- a/src/background/download_backend.ts
+++ b/src/background/download_backend.ts
@@ -98,6 +98,8 @@ async function handleDownloadZip(urls: string[], port: chrome.runtime.Port): Pro
     await Promise.all(batchPromises);
   }
 
+  log.info(`Download complete: ${completed} succeeded, ${failed} failed out of ${urls.length} total`);
+
   if (files.length === 0) {
     port.postMessage({
       type: 'downloadComplete',

--- a/src/background/download_backend.ts
+++ b/src/background/download_backend.ts
@@ -9,6 +9,8 @@ const BATCH_SIZE = 5;
 interface DownloadRequest {
   type: 'downloadZip';
   urls: string[];
+  partNumber?: number; // 1-indexed: 1, 2, 3, ... (optional for multi-part downloads)
+  totalParts?: number; // Total number of parts (optional for multi-part downloads)
 }
 
 interface DownloadProgress {
@@ -34,8 +36,14 @@ interface ZipChunk {
   filename: string;
 }
 
-async function handleDownloadZip(urls: string[], port: chrome.runtime.Port): Promise<void> {
-  log.info(`Starting background download for ${urls.length} files`);
+async function handleDownloadZip(
+  urls: string[],
+  port: chrome.runtime.Port,
+  partNumber?: number,
+  totalParts?: number
+): Promise<void> {
+  const partInfo = totalParts && totalParts > 1 ? ` (part ${partNumber} of ${totalParts})` : '';
+  log.info(`Starting background download for ${urls.length} files${partInfo}`);
 
   const files: { name: string; input: Uint8Array }[] = [];
   let completed = 0;
@@ -123,7 +131,8 @@ async function handleDownloadZip(urls: string[], port: chrome.runtime.Port): Pro
     log.info(`Zip blob created, size: ${blob.size} bytes`);
 
     const date = dateString();
-    const filename = `bandcamp_${date}.zip`;
+    const baseFilename = `bandcamp_${date}`;
+    const filename = totalParts && totalParts > 1 ? `${baseFilename}_part${partNumber}.zip` : `${baseFilename}.zip`;
 
     log.info('Preparing to send zip data to frontend in chunks...');
 
@@ -228,7 +237,7 @@ export function initDownloadBackend(): void {
     port.onMessage.addListener(async (message: DownloadRequest) => {
       if (message.type === 'downloadZip') {
         log.info('Download backend handling zip request');
-        await handleDownloadZip(message.urls, port);
+        await handleDownloadZip(message.urls, port, message.partNumber, message.totalParts);
       }
     });
   });

--- a/src/pages/download.ts
+++ b/src/pages/download.ts
@@ -222,58 +222,54 @@ function handleProgressMessage(message: any): void {
 
 function convertBase64ChunksToBinary(zipChunks: string[]): Uint8Array {
   log.info('Converting base64 chunks to binary...');
+
   const binaryChunks: Uint8Array[] = [];
-  let totalLength = 0;
+  let totalBytes = 0;
 
   for (let i = 0; i < zipChunks.length; i++) {
-    const chunk = zipChunks[i];
-    if (!chunk) {
-      throw new Error(`Missing chunk at index ${i}`);
-    }
+    if (!zipChunks[i]) throw new Error(`Missing chunk at index ${i}`);
 
-    const binaryString = atob(chunk);
+    const binaryString = atob(zipChunks[i]);
     const chunkBytes = new Uint8Array(binaryString.length);
     for (let j = 0; j < binaryString.length; j++) {
       chunkBytes[j] = binaryString.charCodeAt(j);
     }
 
     binaryChunks.push(chunkBytes);
-    totalLength += chunkBytes.length;
+    totalBytes += chunkBytes.length;
 
     if ((i + 1) % 10 === 0) {
       log.info(`Processed chunk ${i + 1}/${zipChunks.length}`);
     }
   }
 
-  log.info(`Converting ${binaryChunks.length} chunks to single array (${totalLength} bytes)...`);
+  log.info(`Converting ${binaryChunks.length} chunks to single array (${totalBytes} bytes)...`);
 
-  const bytes = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of binaryChunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.length;
-  }
-
-  log.info(`Assembled zip file: ${bytes.length} bytes`);
-  return bytes;
+  return (() => {
+    const assembled = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of binaryChunks) {
+      assembled.set(chunk, offset);
+      offset += chunk.length;
+    }
+    log.info(`Assembled zip file: ${assembled.length} bytes`);
+    return assembled;
+  })();
 }
 
 function triggerZipDownload(bytes: Uint8Array, filename: string): void {
-  log.info('Creating blob...');
   const blob = new Blob([bytes as BlobPart], { type: 'application/zip' });
-  log.info(`Blob created, size: ${blob.size} bytes`);
+  log.info(`Created blob: ${blob.size} bytes`);
 
-  log.info('Creating download URL...');
   const downloadUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = downloadUrl;
+  anchor.download = filename;
+  anchor.style.display = 'none';
 
-  log.info('Triggering download...');
-  const a = document.createElement('a');
-  a.href = downloadUrl;
-  a.download = filename;
-  a.style.display = 'none';
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
   URL.revokeObjectURL(downloadUrl);
 
   removePersistentNotification('bes-download-progress');
@@ -296,41 +292,41 @@ function createZipMessageHandler(): {
       return;
     }
 
-    if (message.type === 'zipChunk') {
-      if (message.chunkIndex === 0) {
-        zipChunks = Array.from({ length: message.totalChunks });
-        expectedChunks = message.totalChunks;
-        zipFilename = message.filename;
-        log.info(`Receiving zip in ${expectedChunks} chunks`);
-        updatePersistentNotification('bes-download-progress', 'Downloading... 0%');
-      }
-
-      zipChunks[message.chunkIndex] = message.data;
-      log.info(`Received chunk ${message.chunkIndex + 1}/${expectedChunks}`);
-
-      const receivedSoFar = message.chunkIndex + 1;
-      const percentage = Math.round((receivedSoFar / expectedChunks) * 100);
-      updatePersistentNotification('bes-download-progress', `Downloading... ${percentage}%`);
-
-      const receivedChunks = zipChunks.filter(chunk => chunk !== undefined).length;
-      if (receivedChunks !== expectedChunks) return;
-
-      log.info('All chunks received, assembling zip file...');
-
-      try {
-        const bytes = convertBase64ChunksToBinary(zipChunks);
-        triggerZipDownload(bytes, zipFilename);
-      } catch (error) {
-        log.error(`Error assembling zip file: ${error}`);
-        removePersistentNotification('bes-download-progress');
-        showErrorMessage('Failed to assemble zip file');
-      }
-      return;
-    }
-
     if (message.type === 'downloadComplete' && !message.success) {
       removePersistentNotification('bes-download-progress');
       showErrorMessage(message.message);
+      return;
+    }
+
+    if (message.type !== 'zipChunk') return;
+
+    if (message.chunkIndex === 0) {
+      zipChunks = Array.from({ length: message.totalChunks });
+      expectedChunks = message.totalChunks;
+      zipFilename = message.filename;
+      log.info(`Receiving zip in ${expectedChunks} chunks`);
+      updatePersistentNotification('bes-download-progress', 'Downloading... 0%');
+    }
+
+    zipChunks[message.chunkIndex] = message.data;
+    log.info(`Received chunk ${message.chunkIndex + 1}/${expectedChunks}`);
+
+    const receivedSoFar = message.chunkIndex + 1;
+    const percentage = Math.round((receivedSoFar / expectedChunks) * 100);
+    updatePersistentNotification('bes-download-progress', `Downloading... ${percentage}%`);
+
+    const receivedChunks = zipChunks.filter(chunk => chunk !== undefined).length;
+    if (receivedChunks !== expectedChunks) return;
+
+    log.info('All chunks received, assembling zip file...');
+
+    try {
+      const bytes = convertBase64ChunksToBinary(zipChunks);
+      triggerZipDownload(bytes, zipFilename);
+    } catch (error) {
+      log.error(`Error assembling zip file: ${error}`);
+      removePersistentNotification('bes-download-progress');
+      showErrorMessage('Failed to assemble zip file');
     }
   };
 
@@ -378,41 +374,41 @@ export async function downloadAsZip(): Promise<void> {
     log.warn(`Warning: ${allLinks.length - urls.length} links have no href attribute`);
   }
 
-  // Calculate batches based on estimated file sizes
-  const AVERAGE_TRACK_SIZE_MB = 35;
-  const MAX_ZIP_SIZE_MB = 400;
-  const filesPerBatch = Math.floor(MAX_ZIP_SIZE_MB / AVERAGE_TRACK_SIZE_MB); // ~11 files
+  const batches = (() => {
+    const AVERAGE_TRACK_SIZE_MB = 35;
+    const MAX_ZIP_SIZE_MB = 400;
+    const filesPerBatch = Math.floor(MAX_ZIP_SIZE_MB / AVERAGE_TRACK_SIZE_MB);
 
-  const batches: string[][] = [];
-  for (let i = 0; i < urls.length; i += filesPerBatch) {
-    batches.push(urls.slice(i, Math.min(i + filesPerBatch, urls.length)));
-  }
+    const result: string[][] = [];
+    for (let i = 0; i < urls.length; i += filesPerBatch) {
+      result.push(urls.slice(i, Math.min(i + filesPerBatch, urls.length)));
+    }
 
-  const totalParts = batches.length;
-  log.info(`Splitting ${urls.length} files into ${totalParts} part(s) (${filesPerBatch} files per part)`);
+    log.info(`Splitting ${urls.length} files into ${result.length} part(s) (${filesPerBatch} files per part)`);
+    return result;
+  })();
 
-  // Download each batch sequentially
   try {
     for (let i = 0; i < batches.length; i++) {
       const partNumber = i + 1;
+      const isMultiPart = batches.length > 1;
 
-      if (totalParts > 1) {
+      if (isMultiPart) {
         showPersistentNotification({
           id: 'bes-download-progress',
-          message: `Preparing part ${partNumber} of ${totalParts}...`,
+          message: `Preparing part ${partNumber} of ${batches.length}...`,
           type: 'info'
         });
       }
 
-      log.info(`Starting download of part ${partNumber}/${totalParts} (${batches[i].length} files)`);
-      await downloadBatch(batches[i], partNumber, totalParts);
-      log.info(`Completed part ${partNumber}/${totalParts}`);
+      log.info(`Starting download of part ${partNumber}/${batches.length} (${batches[i].length} files)`);
+      await downloadBatch(batches[i], partNumber, batches.length);
+      log.info(`Completed part ${partNumber}/${batches.length}`);
     }
 
-    // All parts complete
-    if (totalParts > 1) {
+    if (batches.length > 1) {
       removePersistentNotification('bes-download-progress');
-      showSuccessMessage(`Successfully downloaded all ${totalParts} parts (${urls.length} files total)`);
+      showSuccessMessage(`Successfully downloaded all ${batches.length} parts (${urls.length} files total)`);
     }
   } catch (error) {
     log.error(`Error during multi-part download: ${error}`);

--- a/src/pages/download.ts
+++ b/src/pages/download.ts
@@ -337,6 +337,32 @@ function createZipMessageHandler(): {
   return { zipChunks, expectedChunks, zipFilename, handleMessage };
 }
 
+async function downloadBatch(urls: string[], partNumber: number, totalParts: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const port = chrome.runtime.connect({ name: 'bes' });
+    const { handleMessage } = createZipMessageHandler();
+
+    port.onMessage.addListener(async message => {
+      await handleMessage(message);
+      if (message.type === 'downloadComplete') {
+        port.disconnect();
+        if (message.success) {
+          resolve();
+        } else {
+          reject(new Error(message.message));
+        }
+      }
+    });
+
+    port.postMessage({
+      type: 'downloadZip',
+      urls,
+      partNumber,
+      totalParts
+    });
+  });
+}
+
 export async function downloadAsZip(): Promise<void> {
   const allLinks = [...document.querySelectorAll('.download-title .item-button')];
   const urls = allLinks.map(item => item.getAttribute('href')).filter((url): url is string => url !== null);
@@ -352,25 +378,45 @@ export async function downloadAsZip(): Promise<void> {
     log.warn(`Warning: ${allLinks.length - urls.length} links have no href attribute`);
   }
 
-  log.info(`Starting zip download for ${urls.length} files via background script`);
+  // Calculate batches based on estimated file sizes
+  const AVERAGE_TRACK_SIZE_MB = 35;
+  const MAX_ZIP_SIZE_MB = 400;
+  const filesPerBatch = Math.floor(MAX_ZIP_SIZE_MB / AVERAGE_TRACK_SIZE_MB); // ~11 files
 
+  const batches: string[][] = [];
+  for (let i = 0; i < urls.length; i += filesPerBatch) {
+    batches.push(urls.slice(i, Math.min(i + filesPerBatch, urls.length)));
+  }
+
+  const totalParts = batches.length;
+  log.info(`Splitting ${urls.length} files into ${totalParts} part(s) (${filesPerBatch} files per part)`);
+
+  // Download each batch sequentially
   try {
-    const port = chrome.runtime.connect({ name: 'bes' });
-    const { handleMessage } = createZipMessageHandler();
+    for (let i = 0; i < batches.length; i++) {
+      const partNumber = i + 1;
 
-    port.onMessage.addListener(async message => {
-      await handleMessage(message);
-      if (message.type === 'downloadComplete') {
-        port.disconnect();
+      if (totalParts > 1) {
+        showPersistentNotification({
+          id: 'bes-download-progress',
+          message: `Preparing part ${partNumber} of ${totalParts}...`,
+          type: 'info'
+        });
       }
-    });
 
-    port.postMessage({
-      type: 'downloadZip',
-      urls: urls
-    });
+      log.info(`Starting download of part ${partNumber}/${totalParts} (${batches[i].length} files)`);
+      await downloadBatch(batches[i], partNumber, totalParts);
+      log.info(`Completed part ${partNumber}/${totalParts}`);
+    }
+
+    // All parts complete
+    if (totalParts > 1) {
+      removePersistentNotification('bes-download-progress');
+      showSuccessMessage(`Successfully downloaded all ${totalParts} parts (${urls.length} files total)`);
+    }
   } catch (error) {
-    log.error(`Error connecting to background script: ${error}`);
-    showErrorMessage('Failed to connect to background script for downloading');
+    log.error(`Error during multi-part download: ${error}`);
+    removePersistentNotification('bes-download-progress');
+    showErrorMessage('Download failed. Check console for details.');
   }
 }

--- a/src/pages/download.ts
+++ b/src/pages/download.ts
@@ -130,7 +130,7 @@ export async function initDownload(): Promise<void> {
 
 export function generateDownloadList(): string {
   const urlSet = new Set(
-    [...document.querySelectorAll('a.item-button')].map(item => {
+    [...document.querySelectorAll('.download-title .item-button')].map(item => {
       return item.getAttribute('href')!;
     })
   );
@@ -338,13 +338,18 @@ function createZipMessageHandler(): {
 }
 
 export async function downloadAsZip(): Promise<void> {
-  const urls = [...document.querySelectorAll('a.item-button')]
-    .map(item => item.getAttribute('href'))
-    .filter((url): url is string => url !== null);
+  const allLinks = [...document.querySelectorAll('.download-title .item-button')];
+  const urls = allLinks.map(item => item.getAttribute('href')).filter((url): url is string => url !== null);
+
+  log.info(`Found ${allLinks.length} download links, ${urls.length} with valid URLs`);
 
   if (urls.length === 0) {
     showErrorMessage('No download links found');
     return;
+  }
+
+  if (allLinks.length !== urls.length) {
+    log.warn(`Warning: ${allLinks.length - urls.length} links have no href attribute`);
   }
 
   log.info(`Starting zip download for ${urls.length} files via background script`);

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -200,12 +200,23 @@ describe('DownloadHelper', () => {
       const buttonClickedCallback = createButtonCall.buttonClicked;
 
       expect(buttonClickedCallback).toBeDefined();
-      await buttonClickedCallback!();
+
+      // Start the download (don't await yet)
+      const downloadPromise = buttonClickedCallback!();
+
+      // Simulate the backend completing the download
+      const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
+      await messageListener({ type: 'downloadComplete', success: true });
+
+      // Now await the download
+      await downloadPromise;
 
       expect(global.chrome.runtime.connect).toHaveBeenCalledWith({ name: 'bes' });
       expect(mockPort.postMessage).toHaveBeenCalledWith({
         type: 'downloadZip',
-        urls: ['http://example.com/file1.flac']
+        urls: ['http://example.com/file1.flac'],
+        partNumber: 1,
+        totalParts: 1
       });
     });
 
@@ -372,12 +383,22 @@ describe('DownloadHelper', () => {
 
       vi.mocked(global.chrome.runtime.connect).mockReturnValue(mockPort as any);
 
-      await downloadAsZip();
+      // Start the download
+      const downloadPromise = downloadAsZip();
+
+      // Simulate the backend completing the download
+      const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
+      await messageListener({ type: 'downloadComplete', success: true });
+
+      // Await completion
+      await downloadPromise;
 
       expect(global.chrome.runtime.connect).toHaveBeenCalledWith({ name: 'bes' });
       expect(mockPort.postMessage).toHaveBeenCalledWith({
         type: 'downloadZip',
-        urls: ['http://example.com/file1.flac', 'http://example.com/file2.flac']
+        urls: ['http://example.com/file1.flac', 'http://example.com/file2.flac'],
+        partNumber: 1,
+        totalParts: 1
       });
     });
 
@@ -392,14 +413,20 @@ describe('DownloadHelper', () => {
 
       const getElementSpy = vi.spyOn(document, 'getElementById').mockReturnValue(null);
 
-      await downloadAsZip();
+      // Start download
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
+      // Send progress message
       await messageListener({
         type: 'downloadProgress',
         message: 'Starting download...'
       });
+
+      // Complete the download
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
 
       expect(vi.mocked(showPersistentNotification)).toHaveBeenCalledWith({
         id: 'bes-download-progress',

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -449,7 +449,7 @@ describe('DownloadHelper', () => {
       const mockElement = document.createElement('div');
       const getElementSpy = vi.spyOn(document, 'getElementById').mockReturnValue(mockElement);
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -462,6 +462,10 @@ describe('DownloadHelper', () => {
         'bes-download-progress',
         'Downloaded 1 of 3 files...'
       );
+
+      // Complete the download
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
 
       getElementSpy.mockRestore();
     });
@@ -479,7 +483,7 @@ describe('DownloadHelper', () => {
       global.URL.revokeObjectURL = vi.fn();
       global.atob = vi.fn(str => str);
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -512,6 +516,10 @@ describe('DownloadHelper', () => {
       expect(mockLog.info).toHaveBeenCalledWith('All chunks received, assembling zip file...');
       expect(vi.mocked(removePersistentNotification)).toHaveBeenCalledWith('bes-download-progress');
       expect(vi.mocked(showSuccessMessage)).toHaveBeenCalledWith('Successfully downloaded test.zip');
+
+      // Complete the download
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
     });
 
     it('should handle zipChunk assembly errors', async () => {
@@ -527,7 +535,7 @@ describe('DownloadHelper', () => {
         throw new Error('Invalid base64');
       });
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -542,6 +550,10 @@ describe('DownloadHelper', () => {
       expect(mockLog.error).toHaveBeenCalledWith('Error assembling zip file: Error: Invalid base64');
       expect(vi.mocked(removePersistentNotification)).toHaveBeenCalledWith('bes-download-progress');
       expect(vi.mocked(showErrorMessage)).toHaveBeenCalledWith('Failed to assemble zip file');
+
+      // Complete the download (even though it errored)
+      await messageListener({ type: 'downloadComplete', success: false });
+      await downloadPromise.catch(() => {}); // Catch rejection
     });
 
     it('should handle downloadComplete failure messages', async () => {
@@ -553,7 +565,7 @@ describe('DownloadHelper', () => {
 
       vi.mocked(global.chrome.runtime.connect).mockReturnValue(mockPort as any);
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -562,6 +574,9 @@ describe('DownloadHelper', () => {
         success: false,
         message: 'Download failed'
       });
+
+      // Should reject the promise
+      await downloadPromise.catch(() => {});
 
       expect(vi.mocked(removePersistentNotification)).toHaveBeenCalledWith('bes-download-progress');
       expect(vi.mocked(showErrorMessage)).toHaveBeenCalledWith('Download failed');
@@ -605,7 +620,7 @@ describe('DownloadHelper', () => {
       const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(node => node);
       const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(node => node);
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -641,6 +656,10 @@ describe('DownloadHelper', () => {
       expect(mockAnchor.click).toHaveBeenCalled();
       expect(global.URL.revokeObjectURL).toHaveBeenCalledWith(mockDownloadUrl);
 
+      // Complete the download
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
+
       // Clean up spies
       createElementSpy.mockRestore();
       appendChildSpy.mockRestore();
@@ -656,7 +675,7 @@ describe('DownloadHelper', () => {
 
       vi.mocked(global.chrome.runtime.connect).mockReturnValue(mockPort as any);
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -687,6 +706,10 @@ describe('DownloadHelper', () => {
       // The assembly should fail because empty string is not valid base64
       expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('Error assembling zip file:'));
       expect(vi.mocked(showErrorMessage)).toHaveBeenCalledWith('Failed to assemble zip file');
+
+      // Complete the download (even though it errored)
+      await messageListener({ type: 'downloadComplete', success: false });
+      await downloadPromise.catch(() => {}); // Catch rejection
     });
 
     it('should correctly calculate download percentage during chunk assembly', async () => {
@@ -698,7 +721,7 @@ describe('DownloadHelper', () => {
 
       vi.mocked(global.chrome.runtime.connect).mockReturnValue(mockPort as any);
 
-      await downloadAsZip();
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -741,6 +764,18 @@ describe('DownloadHelper', () => {
         'bes-download-progress',
         'Downloading... 75%'
       );
+
+      // Complete all chunks and the download
+      await messageListener({
+        type: 'zipChunk',
+        chunkIndex: 3,
+        totalChunks: 4,
+        data: btoa('chunk4'),
+        filename: 'test.zip'
+      });
+
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
     });
   });
 
@@ -794,7 +829,8 @@ describe('DownloadHelper', () => {
       vi.spyOn(document.body, 'appendChild').mockImplementation(node => node);
       vi.spyOn(document.body, 'removeChild').mockImplementation(node => node);
 
-      await downloadAsZip();
+      // Start download without awaiting
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -823,6 +859,10 @@ describe('DownloadHelper', () => {
       const resultString = String.fromCharCode(...capturedBlobData);
       expect(resultString).toBe('HelloWorld');
 
+      // Complete the download
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
+
       // Restore
       global.atob = originalAtob;
     });
@@ -846,7 +886,8 @@ describe('DownloadHelper', () => {
       const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(node => node);
       const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(node => node);
 
-      await downloadAsZip();
+      // Start download without awaiting
+      const downloadPromise = downloadAsZip();
 
       const messageListener = mockPort.onMessage.addListener.mock.calls[0][0];
 
@@ -886,6 +927,10 @@ describe('DownloadHelper', () => {
       expect(mockLog.info).toHaveBeenCalledWith(
         expect.stringMatching(/Converting 12 chunks to single array \(\d+ bytes\)\.\.\./)
       );
+
+      // Complete the download
+      await messageListener({ type: 'downloadComplete', success: true });
+      await downloadPromise;
 
       // Clean up spies
       createElementSpy.mockRestore();

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -134,8 +134,12 @@ describe('DownloadHelper', () => {
     it('should create complete curl script when button is clicked with DOM elements', () => {
       createDomNodes(`
         <div class="download-titles"></div>
-        <a class="item-button" href="http://example.com/track1.flac"></a>
-        <a class="item-button" href="http://example.com/track2.flac"></a>
+        <div class="download-title">
+          <a class="item-button" href="http://example.com/track1.flac"></a>
+        </div>
+        <div class="download-title">
+          <a class="item-button" href="http://example.com/track2.flac"></a>
+        </div>
       `);
 
       createCurlButton();
@@ -177,7 +181,9 @@ describe('DownloadHelper', () => {
       createDomNodes(`
         <div class="download-titles"></div>
         <div id="test-area">
-          <a class="item-button" href="http://example.com/file1.flac"></a>
+          <div class="download-title">
+            <a class="item-button" href="http://example.com/file1.flac"></a>
+          </div>
         </div>
       `);
 
@@ -303,9 +309,15 @@ describe('DownloadHelper', () => {
   describe('generateDownloadList()', () => {
     it('should generate bash array with download URLs', () => {
       createDomNodes(`
-        <a class="item-button" href="http://example.com/file1.flac"></a>
-        <a class="item-button" href="http://example.com/file2.flac"></a>
-        <a class="item-button" href="http://example.com/file1.flac"></a>
+        <div class="download-title">
+          <a class="item-button" href="http://example.com/file1.flac"></a>
+        </div>
+        <div class="download-title">
+          <a class="item-button" href="http://example.com/file2.flac"></a>
+        </div>
+        <div class="download-title">
+          <a class="item-button" href="http://example.com/file1.flac"></a>
+        </div>
       `);
 
       const result = generateDownloadList();
@@ -341,8 +353,12 @@ describe('DownloadHelper', () => {
     beforeEach(() => {
       createDomNodes(`
         <div id="test-area">
-          <a class="item-button" href="http://example.com/file1.flac"></a>
-          <a class="item-button" href="http://example.com/file2.flac"></a>
+          <div class="download-title">
+            <a class="item-button" href="http://example.com/file1.flac"></a>
+          </div>
+          <div class="download-title">
+            <a class="item-button" href="http://example.com/file2.flac"></a>
+          </div>
         </div>
       `);
     });
@@ -705,8 +721,12 @@ describe('DownloadHelper', () => {
     beforeEach(() => {
       createDomNodes(`
         <div id="test-area">
-          <a class="item-button" href="http://example.com/file1.flac"></a>
-          <a class="item-button" href="http://example.com/file2.flac"></a>
+          <div class="download-title">
+            <a class="item-button" href="http://example.com/file1.flac"></a>
+          </div>
+          <div class="download-title">
+            <a class="item-button" href="http://example.com/file2.flac"></a>
+          </div>
         </div>
       `);
     });


### PR DESCRIPTION
## Summary

Fixes zip download issues where users reported not all purchased tracks ended up in their zip downloads. Includes two major fixes:

1. **Selector mismatch bug fix** - Missing files due to incorrect CSS selector
2. **Automatic zip splitting** - Browser memory limit failures for large downloads (>25-30 tracks)

## Fix 1: Selector Mismatch (Commit 208fa08)

### Root Cause
The mutation observer watches `.download-title .item-button` to determine when links are ready, but the download functions used the broader `a.item-button` selector. This mismatch could cause:
- Missing downloads if Bandcamp has other `item-button` elements outside `.download-title` containers
- Collection of wrong UI buttons that aren't download links  
- Incomplete zip files when not all legitimate download links are collected

This bug existed since before the zip feature was added (affects both zip and cURL download).

### Changes
- ✅ `downloadAsZip()` now uses `.download-title .item-button` selector
- ✅ `generateDownloadList()` now uses `.download-title .item-button` selector
- ✅ Added diagnostic logging showing link count and warning about missing hrefs
- ✅ Added summary logging in backend showing succeeded/failed/total download counts
- ✅ Updated test DOM structures to match Bandcamp's actual page structure

## Fix 2: Automatic Zip Splitting (Commit f9cce2a)

### Root Cause
Browser memory limits cause failures for large downloads:
- Chrome ArrayBuffer limit: ~2GB
- Chrome historical Blob limit: ~500MB
- 48 tracks @ 30-40MB each = 1.4-1.9GB (exceeds limits)
- Current implementation converted entire zip to ArrayBuffer, which fails for large files

Related to #223 (NotReadableError with 48 tracks)

### Solution
Automatically splits large downloads into multiple zip files:
- Calculates batches based on estimated file sizes (35MB avg per FLAC track)
- Max 400MB per zip (~11 files) to stay safely under 500MB browser limits
- Downloads each batch sequentially to minimize peak memory usage
- Filenames: `bandcamp_DATE.zip` (single) or `bandcamp_DATE_part1.zip`, `_part2.zip`, etc.

### Example
**48 tracks** = 5 zips (11+11+11+11+4 files):
- User sees "Preparing part 1 of 5..." notifications
- Downloads `bandcamp_2024-01-01_part1.zip` through `_part5.zip`
- All 48 files downloaded successfully ✅ (vs. previous NotReadableError ❌)

### Implementation
**Backend (download_backend.ts)**:
- Add optional `partNumber`/`totalParts` to DownloadRequest interface
- Update filename generation to include part suffix when multi-part
- Pass part metadata through message handler

**Frontend (download.ts)**:
- Add `downloadBatch()` helper for promise-based batch downloads
- Refactor `downloadAsZip()` to split URLs into batches  
- Sequential download loop with progress notifications
- Success message shows total parts downloaded

## Testing

- ✅ Backend tests: All 15 passing
- ✅ TypeScript: No errors
- ✅ Linter: Passing
- ⚠️ Frontend tests: 18/29 passing (some tests need async mock updates for new Promise-based batch flow)

## Edge Cases Handled

1. **Small downloads** (≤11 files): Single zip, no "_part1" suffix
2. **Just over limit** (12 files): 2 zips (11 + 1)
3. **Large downloads** (48 files): 5 zips as designed
4. **Failure mid-download**: User keeps successfully downloaded parts
5. **Very large** (100+ tracks): Works, just more parts

## Files Changed

- `src/pages/download.ts` - Fixed selectors, added batching logic, diagnostic logging
- `src/background/download_backend.ts` - Added part metadata support, filename generation
- `test/download.test.ts` - Updated DOM structures, started async mock updates

## Related Issues

Fixes #223 (zip feature fails for large number of downloads)