### PR TITLE
Add preview controls to the music feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The goal of this extension is to make Bandcamp easier to use when navigating lar
 
 Provides a "Preview" button on pages with multiple albums. This button will open a player on the same page giving a quick and easy way to listen to tracks without having to navigate away from the page.
 
+### Feed Preview
+
+Adds a "Preview" button to each release in your Bandcamp feed (`bandcamp.com`), both the main feed stories and the "new releases" sidebar. This opens a full player with a tracklist directly in the feed, letting you scan through a track, jump between songs on the album, and work through your backlog without opening every release in a new tab.
+
 ### History Tracking
 
 Adds a history display element next to album. This element is a clickable toggle which persists between page loads thus providing a history. This toggle is automatically set when `preview` button is used and can be manually clicked.

--- a/src/label_view.ts
+++ b/src/label_view.ts
@@ -1,4 +1,5 @@
 import Logger from './logger';
+import { attachPreviewListeners } from './utilities.js';
 
 export function setHistory(id: string, state: boolean): void {
   const historybox = document.querySelector(`#${CSS.escape(id)} .historybox`);
@@ -138,12 +139,7 @@ export function renderDom(
     setPreviewed(id, port);
   }
 
-  const _openFrame = document.querySelectorAll('.open-iframe').forEach(item => {
-    item.addEventListener('click', event => {
-      fillFrame(event, previewState);
-      previewClicked(event, port);
-    });
-  });
+  attachPreviewListeners(document, port, previewState);
 
   const _historybox = document.querySelectorAll('.historybox').forEach(item => {
     item.addEventListener('click', event => {

--- a/src/label_view.ts
+++ b/src/label_view.ts
@@ -34,7 +34,7 @@ export function fillFrame(event: Event, previewState: { previewOpen: boolean; pr
     }
   });
 
-  const preview = (event.target as HTMLElement).closest('.music-grid-item')?.querySelector('.preview-frame');
+  const preview = (event.target as HTMLElement).closest('.preview')?.querySelector('.preview-frame');
   if (!preview) return;
 
   const idAndType = preview.getAttribute('id');

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { initPlayer, updateKeyboardHandlers } from './player';
 import { initAudioFeatures } from './audioFeatures';
 import { initCart } from './pages/cart';
 import { initHideUnhide } from './pages/hide_unhide_collection';
+import { initFeed } from './pages/feed';
 import { createKeyboardSettingsSection } from './components/keyboardSettings.js';
 import { KeyboardSettings } from './types/keyboard.js';
 
@@ -446,6 +447,11 @@ const main = async (): Promise<void> => {
   const checkIsCollectionPage: Element | null = document.querySelector('ol.collection-grid.editable.ui-sortable');
   if (checkIsCollectionPage) {
     await initHideUnhide(config_port);
+  }
+
+  const checkIsFeedPage: Element | null = document.querySelector('#stories');
+  if (checkIsFeedPage) {
+    await initFeed(config_port);
   }
 
   initBESDrawer(config_port);

--- a/src/pages/feed.ts
+++ b/src/pages/feed.ts
@@ -1,0 +1,69 @@
+import Logger from '../logger';
+import { generatePreview, fillFrame, previewClicked } from '../label_view.js';
+
+// Feed album/track items reuse Bandcamp's `collection-item-container` markup which
+// exposes `data-tralbumid` + `data-tralbumtype` (the same attributes the artist/label
+// page preview relies on). `initFeed` only runs on the feed page, so a page-scoped
+// query is enough to find every previewable item regardless of how stories are nested.
+const FEED_ITEM_SELECTOR = '.collection-item-container[data-tralbumid][data-tralbumtype]';
+
+export function tralbumTypeToIdType(tralbumType: string): string | null {
+  if (tralbumType === 'a') return 'album';
+  if (tralbumType === 't') return 'track';
+  return null;
+}
+
+export function renderFeedPreviews(
+  port: chrome.runtime.Port,
+  previewState: { previewOpen: boolean; previewId?: string }
+): void {
+  document.querySelectorAll(FEED_ITEM_SELECTOR).forEach(item => {
+    const container = item as HTMLElement;
+    if (container.dataset.besPreview === 'true') return;
+
+    const id = container.dataset.tralbumid;
+    const idType = tralbumTypeToIdType(container.dataset.tralbumtype || '');
+    if (!id || !idType) return;
+
+    container.dataset.besPreview = 'true';
+
+    const preview = generatePreview(id, idType);
+    // The feed only needs the preview player itself, not the artist-page history toggle.
+    preview.querySelector('.historybox')?.remove();
+
+    // Main feed stories nest the previewable container (`.story-innards`) around a large
+    // layout; append next to the title/art (`.tralbum-details`) so the button is visible
+    // rather than buried below the tags footer. Grid items have no `.tralbum-details`, so
+    // they keep appending to the container itself.
+    const anchor = container.classList.contains('story-innards')
+      ? container.querySelector('.tralbum-details') || container
+      : container;
+    anchor.appendChild(preview);
+
+    preview.querySelectorAll('.open-iframe').forEach(button => {
+      button.addEventListener('click', event => {
+        fillFrame(event, previewState);
+        // Record the preview so it surfaces in the artist/label page history.
+        previewClicked(event, port);
+      });
+    });
+  });
+}
+
+export async function initFeed(port: chrome.runtime.Port): Promise<void> {
+  const log = new Logger();
+  const previewState: { previewOpen: boolean; previewId?: string } = { previewOpen: false, previewId: undefined };
+
+  log.info('Rendering BES feed previews...');
+  renderFeedPreviews(port, previewState);
+
+  // The feed lazily appends more stories as the user scrolls, so re-render whenever
+  // new nodes arrive. Disconnect while we mutate the DOM ourselves to avoid re-triggering.
+  const feedContainer = document.getElementById('stories') || document.body;
+  const observer = new MutationObserver(() => {
+    observer.disconnect();
+    renderFeedPreviews(port, previewState);
+    observer.observe(feedContainer, { childList: true, subtree: true });
+  });
+  observer.observe(feedContainer, { childList: true, subtree: true });
+}

--- a/src/pages/feed.ts
+++ b/src/pages/feed.ts
@@ -1,13 +1,10 @@
 import Logger from '../logger';
-import { generatePreview, fillFrame, previewClicked } from '../label_view.js';
+import { generatePreview } from '../label_view.js';
+import { attachPreviewListeners } from '../utilities.js';
 
-// Feed album/track items reuse Bandcamp's `collection-item-container` markup which
-// exposes `data-tralbumid` + `data-tralbumtype` (the same attributes the artist/label
-// page preview relies on). `initFeed` only runs on the feed page, so a page-scoped
-// query is enough to find every previewable item regardless of how stories are nested.
 const FEED_ITEM_SELECTOR = '.collection-item-container[data-tralbumid][data-tralbumtype]';
 
-export function tralbumTypeToIdType(tralbumType: string): string | null {
+export function tralbumTypeToIdType(tralbumType?: string): string | null {
   if (tralbumType === 'a') return 'album';
   if (tralbumType === 't') return 'track';
   return null;
@@ -22,31 +19,22 @@ export function renderFeedPreviews(
     if (container.dataset.besPreview === 'true') return;
 
     const id = container.dataset.tralbumid;
-    const idType = tralbumTypeToIdType(container.dataset.tralbumtype || '');
-    if (!id || !idType) return;
+    if (!id) return;
+
+    const idType = tralbumTypeToIdType(container.dataset.tralbumtype);
+    if (!idType) return;
 
     container.dataset.besPreview = 'true';
 
     const preview = generatePreview(id, idType);
-    // The feed only needs the preview player itself, not the artist-page history toggle.
     preview.querySelector('.historybox')?.remove();
 
-    // Main feed stories nest the previewable container (`.story-innards`) around a large
-    // layout; append next to the title/art (`.tralbum-details`) so the button is visible
-    // rather than buried below the tags footer. Grid items have no `.tralbum-details`, so
-    // they keep appending to the container itself.
     const anchor = container.classList.contains('story-innards')
       ? container.querySelector('.tralbum-details') || container
       : container;
     anchor.appendChild(preview);
 
-    preview.querySelectorAll('.open-iframe').forEach(button => {
-      button.addEventListener('click', event => {
-        fillFrame(event, previewState);
-        // Record the preview so it surfaces in the artist/label page history.
-        previewClicked(event, port);
-      });
-    });
+    attachPreviewListeners(preview, port, previewState);
   });
 }
 
@@ -57,8 +45,6 @@ export async function initFeed(port: chrome.runtime.Port): Promise<void> {
   log.info('Rendering BES feed previews...');
   renderFeedPreviews(port, previewState);
 
-  // The feed lazily appends more stories as the user scrolls, so re-render whenever
-  // new nodes arrive. Disconnect while we mutate the DOM ourselves to avoid re-triggering.
   const feedContainer = document.getElementById('stories') || document.body;
   const observer = new MutationObserver(() => {
     observer.disconnect();

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,9 +1,23 @@
 import { openDB, IDBPDatabase } from 'idb';
 import Logger from './logger';
+import { fillFrame, previewClicked } from './label_view.js';
 
 interface MouseEventWithOffset extends MouseEvent {
   offsetX: number;
   target: HTMLElement & { offsetWidth: number };
+}
+
+export function attachPreviewListeners(
+  root: Document | HTMLElement,
+  port: chrome.runtime.Port,
+  previewState: { previewOpen: boolean; previewId?: string }
+): void {
+  root.querySelectorAll('.open-iframe').forEach(button => {
+    button.addEventListener('click', event => {
+      fillFrame(event, previewState);
+      previewClicked(event, port);
+    });
+  });
 }
 
 export function mousedownCallback(e: MouseEventWithOffset): void {

--- a/test/feed.test.ts
+++ b/test/feed.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createDomNodes, cleanupTestNodes } from './utils';
+
+vi.mock('../src/logger', () => ({
+  default: class MockLogger {
+    info = vi.fn();
+    error = vi.fn();
+    debug = vi.fn();
+    warn = vi.fn();
+  }
+}));
+
+import { initFeed, renderFeedPreviews, tralbumTypeToIdType } from '../src/pages/feed';
+
+const mockPort = {
+  postMessage: vi.fn(),
+  onMessage: {
+    addListener: vi.fn()
+  }
+};
+
+const createPreviewState = () => ({ previewOpen: false, previewId: undefined as string | undefined });
+
+describe('Feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The preview button injects a real Bandcamp embedded-player iframe; stop happy-dom
+    // from attempting to network-load it so the suite output stays clean.
+    const happyDOM = (globalThis as any).happyDOM;
+    if (happyDOM?.settings) happyDOM.settings.disableIframePageLoading = true;
+  });
+
+  afterEach(() => {
+    cleanupTestNodes();
+    vi.restoreAllMocks();
+  });
+
+  describe('tralbumTypeToIdType()', () => {
+    it('maps Bandcamp tralbum type codes to embedded player types', () => {
+      expect(tralbumTypeToIdType('a')).toBe('album');
+      expect(tralbumTypeToIdType('t')).toBe('track');
+      expect(tralbumTypeToIdType('x')).toBeNull();
+      expect(tralbumTypeToIdType('')).toBeNull();
+    });
+  });
+
+  describe('renderFeedPreviews()', () => {
+    beforeEach(() => {
+      createDomNodes(`
+        <div id="stories">
+          <ol class="story-list">
+            <li class="story">
+              <div class="collection-item-container" data-tralbumid="12345" data-tralbumtype="a">
+                <a class="item-link" href="https://artist.bandcamp.com/album/foo"></a>
+              </div>
+            </li>
+            <li class="story">
+              <div class="collection-item-container" data-tralbumid="67890" data-tralbumtype="t">
+                <a class="item-link" href="https://artist.bandcamp.com/track/bar"></a>
+              </div>
+            </li>
+            <li class="story">
+              <div class="collection-item-container" data-tralbumid="111" data-tralbumtype="x"></div>
+            </li>
+          </ol>
+        </div>
+      `);
+    });
+
+    it('adds a preview button and frame to each previewable feed item', () => {
+      renderFeedPreviews(mockPort as any, createPreviewState());
+
+      const previews = document.querySelectorAll('.collection-item-container .preview');
+      expect(previews.length).toBe(2);
+
+      const album = document.querySelector('.collection-item-container[data-tralbumid="12345"]')!;
+      expect(album.querySelector('button.open-iframe')?.textContent).toBe('Preview');
+      expect(album.querySelector('.preview-frame')?.getAttribute('id')).toBe('album-12345');
+
+      const track = document.querySelector('.collection-item-container[data-tralbumid="67890"]')!;
+      expect(track.querySelector('.preview-frame')?.getAttribute('id')).toBe('track-67890');
+    });
+
+    it('skips items whose tralbum type is unknown', () => {
+      renderFeedPreviews(mockPort as any, createPreviewState());
+
+      const unknown = document.querySelector('.collection-item-container[data-tralbumid="111"]')!;
+      expect(unknown.querySelector('.preview')).toBeNull();
+      expect((unknown as HTMLElement).dataset.besPreview).toBeUndefined();
+    });
+
+    it('does not render the artist-page history toggle on feed items', () => {
+      renderFeedPreviews(mockPort as any, createPreviewState());
+
+      expect(document.querySelectorAll('.collection-item-container .historybox').length).toBe(0);
+      expect(document.querySelectorAll('.collection-item-container button.open-iframe').length).toBe(2);
+    });
+
+    it('is idempotent and does not add duplicate previews when run again', () => {
+      const previewState = createPreviewState();
+      renderFeedPreviews(mockPort as any, previewState);
+      renderFeedPreviews(mockPort as any, previewState);
+
+      expect(document.querySelectorAll('.collection-item-container .preview').length).toBe(2);
+    });
+
+    it('injects an embedded player iframe when the preview button is clicked', () => {
+      // happy-dom logs an (expected) error because iframe page loading is disabled above.
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      renderFeedPreviews(mockPort as any, createPreviewState());
+
+      const button = document.querySelector(
+        '.collection-item-container[data-tralbumid="12345"] button.open-iframe'
+      ) as HTMLButtonElement;
+      button.click();
+
+      const iframe = document.querySelector(
+        '.collection-item-container[data-tralbumid="12345"] .preview-frame iframe'
+      ) as HTMLIFrameElement;
+      expect(iframe).toBeTruthy();
+      expect(iframe.getAttribute('src')).toContain('EmbeddedPlayer/album=12345');
+      expect(iframe.getAttribute('src')).toContain('tracklist=true');
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({ setTrue: '12345' });
+
+      consoleError.mockRestore();
+    });
+
+    it('places the preview next to the details of a main feed story rather than at the bottom', () => {
+      createDomNodes(`
+        <div id="stories-extra">
+          <div class="story-innards collection-item-container" data-tralbumid="555" data-tralbumtype="a">
+            <div class="tralbum-wrapper">
+              <div class="tralbum-details"><div class="collection-item-title">An Album</div></div>
+            </div>
+            <div class="story-footer"><div class="collection-item-tags">tags</div></div>
+          </div>
+        </div>
+      `);
+
+      renderFeedPreviews(mockPort as any, createPreviewState());
+
+      const story = document.querySelector('.story-innards[data-tralbumid="555"]')!;
+      const details = story.querySelector('.tralbum-details')!;
+      expect(details.querySelector('.preview')).toBeTruthy();
+      // The preview should not be a trailing child of the story (where it would be buried).
+      expect(story.lastElementChild?.classList.contains('preview')).toBe(false);
+    });
+  });
+
+  describe('initFeed()', () => {
+    beforeEach(() => {
+      createDomNodes(`
+        <div id="stories">
+          <ol class="story-list">
+            <li class="story">
+              <div class="collection-item-container" data-tralbumid="12345" data-tralbumtype="a">
+                <a class="item-link" href="https://artist.bandcamp.com/album/foo"></a>
+              </div>
+            </li>
+          </ol>
+        </div>
+      `);
+    });
+
+    it('initializes feed preview functionality without throwing', async () => {
+      await expect(initFeed(mockPort as any)).resolves.not.toThrow();
+      expect(document.querySelector('.collection-item-container .preview')).toBeTruthy();
+      expect(document.querySelector('.collection-item-container .historybox')).toBeNull();
+    });
+  });
+});

--- a/test/feed.test.ts
+++ b/test/feed.test.ts
@@ -41,6 +41,7 @@ describe('Feed', () => {
       expect(tralbumTypeToIdType('t')).toBe('track');
       expect(tralbumTypeToIdType('x')).toBeNull();
       expect(tralbumTypeToIdType('')).toBeNull();
+      expect(tralbumTypeToIdType(undefined)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Implements #258 — adds an inline **Preview** button to each release in the Bandcamp feed (`bandcamp.com`), covering both the main feed stories and the "new releases" sidebar.

Clicking **Preview** opens Bandcamp's embedded player — with the full tracklist and a seek bar — directly in the feed. This lets you scan through a track and preview other songs on an album without opening every release in a new tab.

## Approach

This mirrors the existing artist/label page preview feature for consistency:

- New module `src/pages/feed.ts` reuses `label_view`'s `generatePreview` / `fillFrame` / `previewClicked` helpers and the same CSS classes, so no new styling is needed.
- `fillFrame` in `src/label_view.ts` is made container-agnostic — it now locates the preview frame via the wrapping `.preview` element instead of `.music-grid-item` — so both the artist page and the feed can share it. Behavior on artist pages is unchanged.
- Feed items are matched by the shared `.collection-item-container[data-tralbumid][data-tralbumtype]` markup. On main feed stories the preview is placed next to the album details (`.tralbum-details`) so it's visible rather than buried under the tags footer; the grid items append to the container as before.
- A `MutationObserver` re-renders as more stories lazy-load on scroll.
- The artist-page history toggle is omitted on the feed (it read as an empty button there), but previewing still records history so it surfaces on the artist/label page.

## Testing

- `pnpm test` — 341 passing (8 new in `test/feed.test.ts`)
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- Manually verified on a live logged-in feed: Preview appears on main stories and the new-releases sidebar, opens the embedded player inline, and seek / next-track work.

Closes #258

<img width="673" height="848" alt="PNG image" src="https://github.com/user-attachments/assets/31bfbaa9-a1d1-457b-9efa-22944e31d860" />




🤖 Generated with [Claude Code](https://claude.com/claude-code)