### PR TITLE
Add success animation and in-cart state to add-to-cart buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This will download the files into the same directory the terminal session is in.
 
 Adds buttons on track and album pages to easily add an item to your cart with a single click.
 
+When clicked, the button bounces and turns into a green check to confirm the item was added. Items already in your cart show the check on page load, and hovering it reveals a red ✕ that removes the item from the cart — without opening the cart.
+
 ## Installation
 
 Available from the [Chrome webstore](https://chrome.google.com/webstore/detail/bandcamp-label-view/padcfdpdlnpdojcihidkgjnmleeingep) and [Firefox Addons](https://addons.mozilla.org/en-US/firefox/addon/bandcamp-enhancement-suite)

--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,89 @@ input.currency-input::-webkit-outer-spin-button {
   fill: #fff;
 }
 
+/* Add-to-cart button: swap between the add (+), in-cart (check) and remove (x) icons */
+.one-click-button .bes-cart-icons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.one-click-button .bes-cart-icon {
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.one-click-button .bes-cart-icon .icon {
+  height: 10px;
+  width: 10px;
+}
+
+.one-click-button[data-cart-state='add'] .bes-cart-icon-add {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='in-cart'] .bes-cart-icon-check {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='in-cart'] .icon-check {
+  fill: #2ca84f;
+}
+
+.one-click-button[data-cart-state='in-cart']:is(:hover, :active) {
+  background-color: #fdeaea;
+}
+
+.one-click-button[data-cart-state='in-cart']:hover .bes-cart-icon-check {
+  display: none;
+}
+
+.one-click-button[data-cart-state='in-cart']:hover .bes-cart-icon-remove {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='in-cart'] .icon-x {
+  fill: #d0021b;
+}
+
+/* Tap/success bounce and failure shake */
+@keyframes besCartBounce {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(0.82);
+  }
+  70% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.one-click-button.bes-cart-bounce {
+  animation: besCartBounce 0.35s ease;
+}
+
+@keyframes besCartShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-2px);
+  }
+  75% {
+    transform: translateX(2px);
+  }
+}
+
+.one-click-button.bes-cart-error {
+  animation: besCartShake 0.3s ease;
+}
+
 .one-click-button-container {
   background-color: #fff;
   border: 1px solid #d9d9d9;

--- a/src/bclient.ts
+++ b/src/bclient.ts
@@ -102,6 +102,41 @@ export function addAlbumToCart(
   });
 }
 
+interface RemoveAlbumFromCartBody {
+  req: string;
+  id: string | number;
+  sync_num: number;
+}
+
+// Removes a line item from the cart. Bandcamp's cart callback handles this with
+// `req=del` + the item id; auth/cart association rides along on the same-origin
+// cookie, exactly as addAlbumToCart relies on it.
+export function removeAlbumFromCart(item_id: string | number, baseUrl: string | null = null): Promise<Response> {
+  const bodyData: RemoveAlbumFromCartBody = {
+    req: 'del',
+    id: item_id,
+    sync_num: 1
+  };
+
+  const body = new URLSearchParams(bodyData as any).toString();
+
+  const url = baseUrl ? `${baseUrl}/cart/cb` : `/cart/cb`;
+
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json, text/javascript, */*; q=0.01',
+      'content-type': 'application/x-www-form-urlencoded',
+      'sec-fetch-dest': 'empty',
+      'sec-fetch-mode': 'cors',
+      'sec-fetch-site': 'same-origin',
+      'x-requested-with': 'XMLHttpRequest'
+    },
+    body: body,
+    mode: 'cors'
+  });
+}
+
 interface TralbumDetailsBody {
   tralbum_type: string;
   band_id: number;

--- a/src/components/cartButton.ts
+++ b/src/components/cartButton.ts
@@ -1,0 +1,157 @@
+import Logger from '../logger';
+import { createInputButtonPair } from './buttons.js';
+import { createShoppingCartItem } from './shoppingCart.js';
+import { createPlusSvgIcon, createCheckSvgIcon, createXSvgIcon } from './svgIcons';
+import { addAlbumToCart, removeAlbumFromCart } from '../bclient';
+
+type CartButtonState = 'add' | 'in-cart';
+
+interface CartItem {
+  item_id: string | number;
+  item_type: string;
+}
+
+export function getCartItems(): CartItem[] {
+  const cartElement = document.querySelector('[data-cart]');
+  if (!cartElement) return [];
+
+  try {
+    const cart = JSON.parse(cartElement.getAttribute('data-cart') || '{}');
+    return Array.isArray(cart.items) ? cart.items : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isItemInCart(itemId: string | number, itemType: string): boolean {
+  return getCartItems().some(item => String(item.item_id) === String(itemId) && item.item_type === itemType);
+}
+
+export function createCartIcons(): HTMLSpanElement {
+  const wrapper = document.createElement('span');
+  wrapper.className = 'bes-cart-icons';
+
+  const states: Array<[string, Element]> = [
+    ['bes-cart-icon-add', createPlusSvgIcon()],
+    ['bes-cart-icon-check', createCheckSvgIcon()],
+    ['bes-cart-icon-remove', createXSvgIcon()]
+  ];
+
+  states.forEach(([className, icon]) => {
+    const slot = document.createElement('span');
+    slot.className = `bes-cart-icon ${className}`;
+    slot.append(icon);
+    wrapper.append(slot);
+  });
+
+  return wrapper;
+}
+
+export function setCartButtonState(button: HTMLElement, state: CartButtonState): void {
+  button.dataset.cartState = state;
+  button.title = state === 'in-cart' ? 'In cart — click to remove' : 'Add to cart';
+}
+
+export function playCartAnimation(button: HTMLElement, animationClass: string): void {
+  button.classList.remove(animationClass);
+  // Force a reflow so re-adding the class restarts the animation on rapid clicks.
+  void button.offsetWidth;
+  button.classList.add(animationClass);
+  button.addEventListener('animationend', () => button.classList.remove(animationClass), { once: true });
+}
+
+interface CreateAddToCartButtonOptions {
+  price: number;
+  currency: string;
+  tralbumId: string;
+  itemTitle: string;
+  type: string;
+  log: Logger;
+}
+
+export function createAddToCartButton(options: CreateAddToCartButtonOptions): HTMLElement {
+  const { price, currency, tralbumId, itemTitle, type, log } = options;
+
+  const pair = createInputButtonPair({
+    inputPrefix: '$',
+    inputSuffix: currency,
+    inputPlaceholder: price,
+    buttonChildElement: createCartIcons(),
+    onButtonClick: value => handleClick(value)
+  });
+  pair.classList.add('one-click-button-container');
+
+  const button = pair.querySelector('.one-click-button') as HTMLButtonElement;
+  setCartButtonState(button, isItemInCart(tralbumId, type) ? 'in-cart' : 'add');
+
+  function handleClick(value: string | number): void {
+    if (button.dataset.cartState === 'in-cart') {
+      handleRemove();
+      return;
+    }
+    handleAdd(value);
+  }
+
+  function handleAdd(value: string | number): void {
+    const numericValue = typeof value === 'string' ? parseFloat(value) : value;
+    if (numericValue < price) {
+      log.error('track price too low');
+      return;
+    }
+
+    playCartAnimation(button, 'bes-cart-bounce');
+
+    addAlbumToCart(tralbumId, numericValue, type)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        setCartButtonState(button, 'in-cart');
+        playCartAnimation(button, 'bes-cart-bounce');
+        addItemToSidecart(numericValue);
+      })
+      .catch(error => {
+        log.error(error);
+        playCartAnimation(button, 'bes-cart-error');
+      });
+  }
+
+  function handleRemove(): void {
+    removeAlbumFromCart(tralbumId)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        setCartButtonState(button, 'add');
+        document.querySelector(`#sidecart_item_${CSS.escape(tralbumId)}`)?.remove();
+      })
+      .catch(error => {
+        log.error(error);
+        playCartAnimation(button, 'bes-cart-error');
+      });
+  }
+
+  function addItemToSidecart(numericValue: number): void {
+    const cartItem = createShoppingCartItem({
+      itemId: tralbumId,
+      itemName: itemTitle,
+      itemPrice: numericValue,
+      itemCurrency: currency
+    });
+
+    const sidecart = document.querySelector('#sidecart') as HTMLElement | null;
+    if (sidecart && sidecart.style.display === 'none') {
+      window.location.reload();
+      return;
+    }
+
+    const itemList = document.querySelector('#item_list');
+    if (itemList) {
+      itemList.append(cartItem);
+    }
+  }
+
+  return pair;
+}

--- a/src/components/svgIcons.ts
+++ b/src/components/svgIcons.ts
@@ -1,4 +1,6 @@
 import plusSvg from '../../svg/plus.svg';
+import checkSvg from '../../svg/check.svg';
+import xSvg from '../../svg/x.svg';
 
 export const createSvgIcon = (svgString: string, classes: string = ''): Element => {
   const svg = new DOMParser().parseFromString(svgString, 'application/xml').documentElement;
@@ -7,3 +9,7 @@ export const createSvgIcon = (svgString: string, classes: string = ''): Element 
 };
 
 export const createPlusSvgIcon = (): Element => createSvgIcon(plusSvg, 'icon-plus');
+
+export const createCheckSvgIcon = (): Element => createSvgIcon(checkSvg, 'icon-check');
+
+export const createXSvgIcon = (): Element => createSvgIcon(xSvg, 'icon-x');

--- a/src/pages/cart.ts
+++ b/src/pages/cart.ts
@@ -1,6 +1,6 @@
 import Logger from '../logger';
 
-import { createButton, createInputButtonPair } from '../components/buttons.js';
+import { createButton } from '../components/buttons.js';
 import { downloadFile, dateString, loadTextFile, createFetchFunction } from '../utilities';
 import { CURRENCY_MINIMUMS, addAlbumToCart, getTralbumDetails } from '../bclient';
 import {
@@ -11,7 +11,7 @@ import {
   removePersistentNotification
 } from '../components/notifications';
 import { createShoppingCartItem } from '../components/shoppingCart.js';
-import { createPlusSvgIcon } from '../components/svgIcons';
+import { createAddToCartButton } from '../components/cartButton';
 
 const BES_SUPPORT_TRALBUM_ID = 1609998585;
 const BES_SUPPORT_TRALBUM_TYPE = 'a';
@@ -621,37 +621,5 @@ export function createBesSupportButton(
   type: string,
   log: Logger
 ): HTMLElement {
-  const pair = createInputButtonPair({
-    inputPrefix: '$',
-    inputSuffix: currency,
-    inputPlaceholder: price,
-    buttonChildElement: createPlusSvgIcon() as HTMLElement,
-    onButtonClick: value => {
-      const numericValue = typeof value === 'string' ? parseFloat(value) : value;
-      if (numericValue < price) {
-        log.error('track price too low');
-        return;
-      }
-
-      addAlbumToCart(tralbumId, numericValue, type).then(response => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const cartItem = createShoppingCartItem({
-          itemId: tralbumId,
-          itemName: itemTitle,
-          itemPrice: numericValue,
-          itemCurrency: currency
-        });
-
-        const itemList = document.querySelector('#item_list');
-        if (!itemList) return;
-        itemList.append(cartItem);
-      });
-    }
-  });
-  pair.classList.add('one-click-button-container');
-
-  return pair;
+  return createAddToCartButton({ price, currency, tralbumId, itemTitle, type, log });
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,9 +1,7 @@
 import Logger from './logger';
 import { mousedownCallback, extractBandFollowInfo, extractFanTralbumData, createFetchFunction } from './utilities.js';
-import { CURRENCY_MINIMUMS, getTralbumDetails, addAlbumToCart } from './bclient';
-import { createInputButtonPair } from './components/buttons.js';
-import { createShoppingCartItem } from './components/shoppingCart.js';
-import { createPlusSvgIcon } from './components/svgIcons';
+import { CURRENCY_MINIMUMS, getTralbumDetails } from './bclient';
+import { createAddToCartButton } from './components/cartButton';
 import { KeyboardSettings, KeyboardAction, DEFAULT_KEYBOARD_SETTINGS, keyBindingToString } from './types/keyboard.js';
 
 interface KeyCombo {
@@ -178,46 +176,7 @@ export function createOneClickBuyButton(
   type: string,
   log: Logger
 ): HTMLElement {
-  const pair = createInputButtonPair({
-    inputPrefix: '$',
-    inputSuffix: currency,
-    inputPlaceholder: price,
-    buttonChildElement: createPlusSvgIcon() as HTMLElement,
-    onButtonClick: value => {
-      const numericValue = typeof value === 'string' ? parseFloat(value) : value;
-      if (numericValue < price) {
-        log.error('track price too low');
-        return;
-      }
-
-      addAlbumToCart(tralbumId, numericValue, type).then(response => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const cartItem = createShoppingCartItem({
-          itemId: tralbumId,
-          itemName: itemTitle,
-          itemPrice: numericValue,
-          itemCurrency: currency
-        });
-
-        const sidecart = document.querySelector('#sidecart') as HTMLElement;
-        if (sidecart && sidecart.style.display === 'none') {
-          window.location.reload();
-          return;
-        }
-
-        const itemList = document.querySelector('#item_list');
-        if (itemList) {
-          itemList.append(cartItem);
-        }
-      });
-    }
-  });
-  pair.classList.add('one-click-button-container');
-
-  return pair;
+  return createAddToCartButton({ price, currency, tralbumId, itemTitle, type, log });
 }
 
 let activeKeyHandlers: KeyHandlers = {};

--- a/svg/check.svg
+++ b/svg/check.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>

--- a/svg/x.svg
+++ b/svg/x.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>

--- a/test/bclient.test.ts
+++ b/test/bclient.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { addAlbumToCart, getTralbumDetails, getCollectionSummary, hideUnhide, getHiddenItems } from '../src/bclient';
+import {
+  addAlbumToCart,
+  removeAlbumFromCart,
+  getTralbumDetails,
+  getCollectionSummary,
+  hideUnhide,
+  getHiddenItems
+} from '../src/bclient';
 
 describe('bclient', () => {
   afterEach(() => {
@@ -68,6 +75,47 @@ describe('bclient', () => {
         expect.objectContaining({
           method: 'POST'
         })
+      );
+    });
+  });
+
+  describe('removeAlbumFromCart', () => {
+    let fetchSpy: any;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{"success": true}', { status: 200 }));
+    });
+
+    it('should make POST request to cart endpoint with req=del and the item id', async () => {
+      await removeAlbumFromCart('123');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/cart/cb',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            accept: 'application/json, text/javascript, */*; q=0.01',
+            'content-type': 'application/x-www-form-urlencoded',
+            'x-requested-with': 'XMLHttpRequest'
+          }),
+          body: 'req=del&id=123&sync_num=1',
+          mode: 'cors'
+        })
+      );
+    });
+
+    it('should return fetch response', async () => {
+      const response = await removeAlbumFromCart('123');
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(200);
+    });
+
+    it('should use absolute URL when baseUrl is provided', async () => {
+      await removeAlbumFromCart('123', 'https://bandcamp.com');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://bandcamp.com/cart/cb',
+        expect.objectContaining({ method: 'POST' })
       );
     });
   });

--- a/test/cartButton.test.ts
+++ b/test/cartButton.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../src/logger', () => ({
+  default: class MockLogger {
+    info = vi.fn();
+    error = vi.fn();
+    debug = vi.fn();
+    warn = vi.fn();
+  }
+}));
+
+vi.mock('../src/bclient', () => ({
+  addAlbumToCart: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+  removeAlbumFromCart: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })))
+}));
+
+import {
+  getCartItems,
+  isItemInCart,
+  createCartIcons,
+  setCartButtonState,
+  createAddToCartButton
+} from '../src/components/cartButton';
+import { addAlbumToCart, removeAlbumFromCart } from '../src/bclient';
+import Logger from '../src/logger';
+
+// setup.ts wipes document.body before each test, so a plain appended node is enough.
+const setCartData = (items: Array<{ item_id: string | number; item_type: string }>) => {
+  const el = document.createElement('div');
+  el.setAttribute('data-cart', JSON.stringify({ items }));
+  document.body.appendChild(el);
+};
+
+const buildButton = (overrides: Record<string, any> = {}) =>
+  createAddToCartButton({
+    price: 1,
+    currency: 'USD',
+    tralbumId: '123',
+    itemTitle: 'Test Album',
+    type: 'a',
+    log: new Logger() as any,
+    ...overrides
+  });
+
+describe('cartButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getCartItems / isItemInCart', () => {
+    it('returns an empty list when there is no cart element', () => {
+      expect(getCartItems()).toEqual([]);
+      expect(isItemInCart('123', 'a')).toBe(false);
+    });
+
+    it('reads items from the [data-cart] blob', () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      expect(getCartItems()).toHaveLength(1);
+    });
+
+    it('matches an item by id and type (coercing id to string)', () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      expect(isItemInCart('123', 'a')).toBe(true);
+      expect(isItemInCart(123, 'a')).toBe(true);
+      expect(isItemInCart('123', 't')).toBe(false);
+      expect(isItemInCart('999', 'a')).toBe(false);
+    });
+
+    it('tolerates malformed cart data', () => {
+      const el = document.createElement('div');
+      el.setAttribute('data-cart', 'not json');
+      document.body.appendChild(el);
+      expect(getCartItems()).toEqual([]);
+    });
+  });
+
+  describe('createCartIcons', () => {
+    it('renders add, check and remove icon slots', () => {
+      const icons = createCartIcons();
+      expect(icons.querySelectorAll('.bes-cart-icon')).toHaveLength(3);
+      expect(icons.querySelector('.bes-cart-icon-add')).toBeTruthy();
+      expect(icons.querySelector('.bes-cart-icon-check')).toBeTruthy();
+      expect(icons.querySelector('.bes-cart-icon-remove')).toBeTruthy();
+    });
+  });
+
+  describe('setCartButtonState', () => {
+    it('sets the data attribute and title', () => {
+      const button = document.createElement('button');
+      setCartButtonState(button, 'in-cart');
+      expect(button.dataset.cartState).toBe('in-cart');
+      expect(button.title.toLowerCase()).toContain('remove');
+
+      setCartButtonState(button, 'add');
+      expect(button.dataset.cartState).toBe('add');
+      expect(button.title.toLowerCase()).toContain('add');
+    });
+  });
+
+  describe('createAddToCartButton', () => {
+    it('starts in the add state when the item is not in the cart', () => {
+      const container = buildButton();
+      const button = container.querySelector('.one-click-button') as HTMLElement;
+      expect(button.dataset.cartState).toBe('add');
+    });
+
+    it('starts in the in-cart state when the item is already in the cart', () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      const container = buildButton();
+      const button = container.querySelector('.one-click-button') as HTMLElement;
+      expect(button.dataset.cartState).toBe('in-cart');
+    });
+
+    it('adds to cart and flips to the in-cart state on a successful click', async () => {
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+
+      button.click();
+
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('in-cart'));
+      expect(addAlbumToCart).toHaveBeenCalledWith('123', 1, 'a');
+    });
+
+    it('removes from cart and reverts to the add state when clicked while in cart', async () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+      expect(button.dataset.cartState).toBe('in-cart');
+
+      button.click();
+
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('add'));
+      expect(removeAlbumFromCart).toHaveBeenCalledWith('123');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #260. The one-click add-to-cart buttons gave no feedback, so it was hard to tell whether an item actually made it into the cart. The button now confirms the action and reflects cart state:

- **Bounces on tap and morphs into a green check** on a confirmed add.
- **Shows the green check on page load** when that track/album is already in the cart (read from the page's `[data-cart]` blob).
- **Hovering the check reveals a red ✕** that removes the item from the cart — without opening the cart.
- **Briefly shakes** if the add/remove request fails.

## How it works

- Adds `removeAlbumFromCart` to `bclient.ts` — `POST /cart/cb` with `req=del` + the item id, mirroring `addAlbumToCart` and relying on the same-origin cookie for auth (the request shape is confirmed against two independent reverse-engineered implementations).
- Adds `check.svg` / `x.svg` and `createCheckSvgIcon` / `createXSvgIcon`.
- Adds a shared `components/cartButton.ts` (`createAddToCartButton`, `isItemInCart`, icon/state/animation helpers). Both the track/album one-click buttons (`player.ts`) and the Support BES button (`cart.ts`) now delegate to it, removing the duplicated add-to-cart logic.
- CSS drives the add → in-cart icon swap, the hover-to-remove ✕, and the bounce/shake animations via a `data-cart-state` attribute.

## Testing

- `pnpm test` — 354 passing (13 new: `removeAlbumFromCart` + the `cartButton` component).
- `pnpm typecheck`, `pnpm lint` (1 pre-existing unrelated warning in `audioFeatures.ts`), `pnpm build` — clean.

### Note for review
`removeAlbumFromCart` is based on the `req=del` cart endpoint reverse-engineered from two independent projects; like the existing `addAlbumToCart` it relies on the same-origin session cookie rather than an explicit `client_id`. I couldn't exercise it against a live authenticated cart, so it's worth a quick manual confirm that remove works end-to-end.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)