### PR TITLE
Add success animation and in-cart controls to add-to-cart buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This will download the files into the same directory the terminal session is in.
 
 Adds buttons on track and album pages to easily add an item to your cart with a single click.
 
+When clicked, the button bounces and turns into a green check to confirm the item was added. Items already in your cart show the check on page load, and hovering it reveals a red ✕ that removes the item from the cart — without opening the cart.
+
 ## Installation
 
 Available from the [Chrome webstore](https://chrome.google.com/webstore/detail/bandcamp-label-view/padcfdpdlnpdojcihidkgjnmleeingep) and [Firefox Addons](https://addons.mozilla.org/en-US/firefox/addon/bandcamp-enhancement-suite)

--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,123 @@ input.currency-input::-webkit-outer-spin-button {
   fill: #fff;
 }
 
+.one-click-button {
+  transition: transform 0.08s ease;
+}
+
+.one-click-button:active {
+  transform: scale(0.9);
+}
+
+.one-click-button .bes-cart-icons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.one-click-button .bes-cart-icon {
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.one-click-button .bes-cart-icon .icon {
+  height: 10px;
+  width: 10px;
+}
+
+.one-click-button .bes-cart-icon-check .icon {
+  height: 15px;
+  width: 15px;
+  margin: -2.5px;
+}
+
+.one-click-button[data-cart-state='add'] .bes-cart-icon-add {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='loading'] {
+  pointer-events: none;
+}
+
+.one-click-button[data-cart-state='loading'] .bes-cart-icon-loading {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='in-cart'] .bes-cart-icon-check {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='in-cart'] .icon-check {
+  fill: #2ca84f;
+}
+
+.one-click-button[data-cart-state='in-cart']:is(:hover, :active) {
+  background-color: #fdeaea;
+}
+
+.one-click-button[data-cart-state='in-cart']:hover .bes-cart-icon-check {
+  display: none;
+}
+
+.one-click-button[data-cart-state='in-cart']:hover .bes-cart-icon-remove {
+  display: flex;
+}
+
+.one-click-button[data-cart-state='in-cart'] .icon-x {
+  fill: #d0021b;
+}
+
+.bes-cart-spinner {
+  display: inline-block;
+  box-sizing: border-box;
+  height: 10px;
+  width: 10px;
+  border: 2px solid rgba(6, 135, 245, 0.25);
+  border-top-color: #0687f5;
+  border-radius: 50%;
+  animation: besCartSpin 0.6s linear infinite;
+}
+
+@keyframes besCartSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes besCartPop {
+  0% {
+    transform: scale(0.4);
+  }
+  60% {
+    transform: scale(1.25);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.one-click-button.bes-cart-pop .bes-cart-icon {
+  animation: besCartPop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes besCartShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-2px);
+  }
+  75% {
+    transform: translateX(2px);
+  }
+}
+
+.one-click-button.bes-cart-error {
+  animation: besCartShake 0.3s ease;
+}
+
 .one-click-button-container {
   background-color: #fff;
   border: 1px solid #d9d9d9;

--- a/src/bclient.ts
+++ b/src/bclient.ts
@@ -102,6 +102,38 @@ export function addAlbumToCart(
   });
 }
 
+interface RemoveAlbumFromCartBody {
+  req: string;
+  id: string | number;
+  sync_num: number;
+}
+
+export function removeAlbumFromCart(item_id: string | number, baseUrl: string | null = null): Promise<Response> {
+  const bodyData: RemoveAlbumFromCartBody = {
+    req: 'del',
+    id: item_id,
+    sync_num: 1
+  };
+
+  const body = new URLSearchParams(bodyData as any).toString();
+
+  const url = baseUrl ? `${baseUrl}/cart/cb` : `/cart/cb`;
+
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json, text/javascript, */*; q=0.01',
+      'content-type': 'application/x-www-form-urlencoded',
+      'sec-fetch-dest': 'empty',
+      'sec-fetch-mode': 'cors',
+      'sec-fetch-site': 'same-origin',
+      'x-requested-with': 'XMLHttpRequest'
+    },
+    body: body,
+    mode: 'cors'
+  });
+}
+
 interface TralbumDetailsBody {
   tralbum_type: string;
   band_id: number;

--- a/src/components/cartButton.ts
+++ b/src/components/cartButton.ts
@@ -16,8 +16,8 @@ interface CartItem {
 }
 
 function removeSidecartRow(lineItemId: string | number | null, tralbumId: string, itemUrl?: string): void {
-  if (lineItemId !== null) document.getElementById(`sidecart_item_${lineItemId}`)?.remove();
-  document.getElementById(`sidecart_item_${tralbumId}`)?.remove();
+  const idsToRemove = lineItemId !== null ? [lineItemId, tralbumId] : [tralbumId];
+  idsToRemove.forEach(id => document.getElementById(`sidecart_item_${id}`)?.remove());
 
   const itemList = document.getElementById('item_list');
   if (!itemList || !itemUrl) return;
@@ -29,14 +29,6 @@ function removeSidecartRow(lineItemId: string | number | null, tralbumId: string
     while (row.parentElement && row.parentElement !== itemList) row = row.parentElement;
     if (row.parentElement === itemList) row.remove();
   });
-}
-
-function parseCartData(element: Element): any {
-  try {
-    return JSON.parse(element.getAttribute('data-cart') || 'null');
-  } catch {
-    return null;
-  }
 }
 
 function extractCartItems(value: any): CartItem[] {
@@ -54,7 +46,14 @@ function extractCartItems(value: any): CartItem[] {
 export function getCartItems(): CartItem[] {
   let fallback: CartItem[] = [];
   for (const element of Array.from(document.querySelectorAll('[data-cart]'))) {
-    const items = extractCartItems(parseCartData(element));
+    let cartData: any;
+    try {
+      cartData = JSON.parse(element.getAttribute('data-cart') || 'null');
+    } catch {
+      continue;
+    }
+    if (!cartData) continue;
+    const items = extractCartItems(cartData);
     if (items.length === 0) continue;
     if (items.some(item => item.id !== undefined && item.id !== null)) return items;
     if (fallback.length === 0) fallback = items;

--- a/src/components/cartButton.ts
+++ b/src/components/cartButton.ts
@@ -1,0 +1,254 @@
+import Logger from '../logger';
+import { createInputButtonPair } from './buttons.js';
+import { createShoppingCartItem } from './shoppingCart.js';
+import { createPlusSvgIcon, createCheckSvgIcon, createXSvgIcon } from './svgIcons';
+import { addAlbumToCart, removeAlbumFromCart } from '../bclient';
+
+type CartButtonState = 'add' | 'loading' | 'in-cart';
+
+const MIN_SPINNER_MS = 250;
+
+interface CartItem {
+  id: string | number;
+  item_id: string | number;
+  item_type: string;
+  url?: string;
+}
+
+function removeSidecartRow(lineItemId: string | number | null, tralbumId: string, itemUrl?: string): void {
+  if (lineItemId !== null) document.getElementById(`sidecart_item_${lineItemId}`)?.remove();
+  document.getElementById(`sidecart_item_${tralbumId}`)?.remove();
+
+  const itemList = document.getElementById('item_list');
+  if (!itemList || !itemUrl) return;
+
+  const base = itemUrl.split('?')[0];
+  itemList.querySelectorAll('a[href]').forEach(link => {
+    if ((link.getAttribute('href') || '').split('?')[0] !== base) return;
+    let row: HTMLElement = link as HTMLElement;
+    while (row.parentElement && row.parentElement !== itemList) row = row.parentElement;
+    if (row.parentElement === itemList) row.remove();
+  });
+}
+
+function parseCartData(element: Element): any {
+  try {
+    return JSON.parse(element.getAttribute('data-cart') || 'null');
+  } catch {
+    return null;
+  }
+}
+
+function extractCartItems(value: any): CartItem[] {
+  if (!value) return [];
+  const items = Array.isArray(value.items)
+    ? value.items
+    : value.cart_data && Array.isArray(value.cart_data.items)
+      ? value.cart_data.items
+      : Array.isArray(value)
+        ? value
+        : [];
+  return items.filter((item: any) => item && typeof item === 'object' && 'item_id' in item);
+}
+
+export function getCartItems(): CartItem[] {
+  let fallback: CartItem[] = [];
+  for (const element of Array.from(document.querySelectorAll('[data-cart]'))) {
+    const items = extractCartItems(parseCartData(element));
+    if (items.length === 0) continue;
+    if (items.some(item => item.id !== undefined && item.id !== null)) return items;
+    if (fallback.length === 0) fallback = items;
+  }
+  return fallback;
+}
+
+export function isItemInCart(itemId: string | number, itemType: string): boolean {
+  return getCartItems().some(item => String(item.item_id) === String(itemId) && item.item_type === itemType);
+}
+
+export function getCartLineItemId(itemId: string | number, itemType: string): string | number | null {
+  const match = getCartItems().find(item => String(item.item_id) === String(itemId) && item.item_type === itemType);
+  return match?.id ?? null;
+}
+
+export function createCartIcons(): HTMLSpanElement {
+  const wrapper = document.createElement('span');
+  wrapper.className = 'bes-cart-icons';
+
+  const makeSlot = (className: string, child: Element): HTMLSpanElement => {
+    const slot = document.createElement('span');
+    slot.className = `bes-cart-icon ${className}`;
+    slot.append(child);
+    return slot;
+  };
+
+  const spinner = document.createElement('span');
+  spinner.className = 'bes-cart-spinner';
+
+  wrapper.append(
+    makeSlot('bes-cart-icon-add', createPlusSvgIcon()),
+    makeSlot('bes-cart-icon-loading', spinner),
+    makeSlot('bes-cart-icon-check', createCheckSvgIcon()),
+    makeSlot('bes-cart-icon-remove', createXSvgIcon())
+  );
+
+  return wrapper;
+}
+
+const STATE_TITLES: Record<CartButtonState, string> = {
+  add: 'Add to cart',
+  loading: 'Working…',
+  'in-cart': 'In cart — click to remove'
+};
+
+export function setCartButtonState(button: HTMLElement, state: CartButtonState): void {
+  button.dataset.cartState = state;
+  button.title = STATE_TITLES[state];
+  button.setAttribute('aria-busy', state === 'loading' ? 'true' : 'false');
+}
+
+export function playCartAnimation(button: HTMLElement, animationClass: string): void {
+  button.classList.remove(animationClass);
+  void button.offsetWidth;
+  button.classList.add(animationClass);
+  button.addEventListener('animationend', () => button.classList.remove(animationClass), { once: true });
+}
+
+function withMinDuration<T>(promise: Promise<T>, ms: number): Promise<T> {
+  const elapsed = new Promise<void>(resolve => setTimeout(resolve, ms));
+  return Promise.all([promise, elapsed]).then(([result]) => result);
+}
+
+async function assertCartResponseOk(response: Response): Promise<any> {
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const body = await response
+    .clone()
+    .json()
+    .catch(() => null);
+  if (body && body.error) {
+    throw new Error(`cart request failed: ${JSON.stringify(body.error)}`);
+  }
+  return body;
+}
+
+interface CreateAddToCartButtonOptions {
+  price: number;
+  currency: string;
+  tralbumId: string;
+  itemTitle: string;
+  type: string;
+  log: Logger;
+}
+
+export function createAddToCartButton(options: CreateAddToCartButtonOptions): HTMLElement {
+  const { price, currency, tralbumId, itemTitle, type, log } = options;
+
+  const pair = createInputButtonPair({
+    inputPrefix: '$',
+    inputSuffix: currency,
+    inputPlaceholder: price,
+    buttonChildElement: createCartIcons(),
+    onButtonClick: value => handleClick(value)
+  });
+  pair.classList.add('one-click-button-container');
+
+  const button = pair.querySelector('.one-click-button') as HTMLButtonElement;
+  let lineItemId = getCartLineItemId(tralbumId, type);
+  setCartButtonState(button, isItemInCart(tralbumId, type) ? 'in-cart' : 'add');
+
+  function handleClick(value: string | number): void {
+    const state = button.dataset.cartState;
+    if (state === 'loading') return;
+    if (state === 'in-cart') {
+      handleRemove();
+      return;
+    }
+    handleAdd(value);
+  }
+
+  function handleAdd(value: string | number): void {
+    const numericValue = typeof value === 'string' ? parseFloat(value) : value;
+    if (numericValue < price) {
+      log.error('track price too low');
+      return;
+    }
+
+    setCartButtonState(button, 'loading');
+
+    withMinDuration(addAlbumToCart(tralbumId, numericValue, type), MIN_SPINNER_MS)
+      .then(assertCartResponseOk)
+      .then(body => {
+        if (body && body.id !== undefined && body.id !== null) {
+          lineItemId = body.id;
+        } else {
+          const added = extractCartItems(body).find(
+            item => String(item.item_id) === String(tralbumId) && item.item_type === type
+          );
+          if (added) lineItemId = added.id;
+        }
+
+        setCartButtonState(button, 'in-cart');
+        playCartAnimation(button, 'bes-cart-pop');
+        addItemToSidecart(numericValue);
+      })
+      .catch(error => {
+        log.error(error);
+        setCartButtonState(button, 'add');
+        playCartAnimation(button, 'bes-cart-error');
+      });
+  }
+
+  function handleRemove(): void {
+    const id = lineItemId ?? getCartLineItemId(tralbumId, type);
+    if (id === null) {
+      log.error('cannot remove from cart: line-item id unknown');
+      playCartAnimation(button, 'bes-cart-error');
+      return;
+    }
+
+    const itemUrl = getCartItems().find(
+      item => String(item.item_id) === String(tralbumId) && item.item_type === type
+    )?.url;
+
+    setCartButtonState(button, 'loading');
+
+    withMinDuration(removeAlbumFromCart(id), MIN_SPINNER_MS)
+      .then(assertCartResponseOk)
+      .then(() => {
+        lineItemId = null;
+        setCartButtonState(button, 'add');
+        playCartAnimation(button, 'bes-cart-pop');
+        removeSidecartRow(id, tralbumId, itemUrl);
+      })
+      .catch(error => {
+        log.error(error);
+        setCartButtonState(button, 'in-cart');
+        playCartAnimation(button, 'bes-cart-error');
+      });
+  }
+
+  function addItemToSidecart(numericValue: number): void {
+    const cartItem = createShoppingCartItem({
+      itemId: tralbumId,
+      itemName: itemTitle,
+      itemPrice: numericValue,
+      itemCurrency: currency,
+      onDelete: () => handleRemove()
+    });
+
+    const sidecart = document.querySelector('#sidecart') as HTMLElement | null;
+    if (sidecart && sidecart.style.display === 'none') {
+      window.location.reload();
+      return;
+    }
+
+    const itemList = document.querySelector('#item_list');
+    if (itemList) {
+      itemList.append(cartItem);
+    }
+  }
+
+  return pair;
+}

--- a/src/components/shoppingCart.ts
+++ b/src/components/shoppingCart.ts
@@ -3,12 +3,13 @@ interface ShoppingCartItemOptions {
   itemName: string;
   itemPrice: number;
   itemCurrency: string;
+  onDelete?: (event: Event) => void;
 }
 
 export function createShoppingCartItem(
   options: ShoppingCartItemOptions = {} as ShoppingCartItemOptions
 ): HTMLDivElement {
-  const { itemId, itemName, itemPrice, itemCurrency } = options;
+  const { itemId, itemName, itemPrice, itemCurrency, onDelete } = options;
 
   const itemContainer = document.createElement('div');
   itemContainer.id = `sidecart_item_${itemId}`;
@@ -28,10 +29,20 @@ export function createShoppingCartItem(
 
   const deleteLink = document.createElement('a');
   deleteLink.className = 'delete notSkinnable';
-  deleteLink.style.pointerEvents = 'none';
   const deleteSpan = document.createElement('span');
-  deleteSpan.textContent = '⊘';
+  deleteSpan.textContent = '×';
   deleteLink.appendChild(deleteSpan);
+
+  if (onDelete) {
+    deleteLink.href = '#';
+    deleteLink.title = 'Remove from cart';
+    deleteLink.addEventListener('click', event => {
+      event.preventDefault();
+      onDelete(event);
+    });
+  } else {
+    deleteLink.style.pointerEvents = 'none';
+  }
 
   const priceSpan = document.createElement('span');
   priceSpan.className = 'price';

--- a/src/components/shoppingCart.ts
+++ b/src/components/shoppingCart.ts
@@ -30,10 +30,10 @@ export function createShoppingCartItem(
   const deleteLink = document.createElement('a');
   deleteLink.className = 'delete notSkinnable';
   const deleteSpan = document.createElement('span');
-  deleteSpan.textContent = '×';
   deleteLink.appendChild(deleteSpan);
 
   if (onDelete) {
+    deleteSpan.textContent = '×';
     deleteLink.href = '#';
     deleteLink.title = 'Remove from cart';
     deleteLink.addEventListener('click', event => {
@@ -41,6 +41,7 @@ export function createShoppingCartItem(
       onDelete(event);
     });
   } else {
+    deleteSpan.textContent = '⊘';
     deleteLink.style.pointerEvents = 'none';
   }
 

--- a/src/components/svgIcons.ts
+++ b/src/components/svgIcons.ts
@@ -1,4 +1,6 @@
 import plusSvg from '../../svg/plus.svg';
+import checkSvg from '../../svg/check.svg';
+import xSvg from '../../svg/x.svg';
 
 export const createSvgIcon = (svgString: string, classes: string = ''): Element => {
   const svg = new DOMParser().parseFromString(svgString, 'application/xml').documentElement;
@@ -7,3 +9,7 @@ export const createSvgIcon = (svgString: string, classes: string = ''): Element 
 };
 
 export const createPlusSvgIcon = (): Element => createSvgIcon(plusSvg, 'icon-plus');
+
+export const createCheckSvgIcon = (): Element => createSvgIcon(checkSvg, 'icon-check');
+
+export const createXSvgIcon = (): Element => createSvgIcon(xSvg, 'icon-x');

--- a/src/pages/cart.ts
+++ b/src/pages/cart.ts
@@ -594,7 +594,14 @@ export async function initCart(port: chrome.runtime.Port): Promise<void> {
       return;
     }
 
-    const oneClick = createBesSupportButton(minimumPrice, currency, String(tralbumId), itemTitle, type, log);
+    const oneClick = createAddToCartButton({
+      price: minimumPrice,
+      currency,
+      tralbumId: String(tralbumId),
+      itemTitle,
+      type,
+      log
+    });
 
     const besSupportText = document.createElement('div');
     besSupportText.innerText = 'Support BES';
@@ -611,15 +618,4 @@ export async function initCart(port: chrome.runtime.Port): Promise<void> {
   } catch (error) {
     log.error(error);
   }
-}
-
-export function createBesSupportButton(
-  price: number,
-  currency: string,
-  tralbumId: string,
-  itemTitle: string,
-  type: string,
-  log: Logger
-): HTMLElement {
-  return createAddToCartButton({ price, currency, tralbumId, itemTitle, type, log });
 }

--- a/src/pages/cart.ts
+++ b/src/pages/cart.ts
@@ -1,6 +1,6 @@
 import Logger from '../logger';
 
-import { createButton, createInputButtonPair } from '../components/buttons.js';
+import { createButton } from '../components/buttons.js';
 import { downloadFile, dateString, loadTextFile, createFetchFunction } from '../utilities';
 import { CURRENCY_MINIMUMS, addAlbumToCart, getTralbumDetails } from '../bclient';
 import {
@@ -11,7 +11,7 @@ import {
   removePersistentNotification
 } from '../components/notifications';
 import { createShoppingCartItem } from '../components/shoppingCart.js';
-import { createPlusSvgIcon } from '../components/svgIcons';
+import { createAddToCartButton } from '../components/cartButton';
 
 const BES_SUPPORT_TRALBUM_ID = 1609998585;
 const BES_SUPPORT_TRALBUM_TYPE = 'a';
@@ -621,37 +621,5 @@ export function createBesSupportButton(
   type: string,
   log: Logger
 ): HTMLElement {
-  const pair = createInputButtonPair({
-    inputPrefix: '$',
-    inputSuffix: currency,
-    inputPlaceholder: price,
-    buttonChildElement: createPlusSvgIcon() as HTMLElement,
-    onButtonClick: value => {
-      const numericValue = typeof value === 'string' ? parseFloat(value) : value;
-      if (numericValue < price) {
-        log.error('track price too low');
-        return;
-      }
-
-      addAlbumToCart(tralbumId, numericValue, type).then(response => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const cartItem = createShoppingCartItem({
-          itemId: tralbumId,
-          itemName: itemTitle,
-          itemPrice: numericValue,
-          itemCurrency: currency
-        });
-
-        const itemList = document.querySelector('#item_list');
-        if (!itemList) return;
-        itemList.append(cartItem);
-      });
-    }
-  });
-  pair.classList.add('one-click-button-container');
-
-  return pair;
+  return createAddToCartButton({ price, currency, tralbumId, itemTitle, type, log });
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -168,17 +168,6 @@ export function volumeSliderCallback(e: Event): void {
   audio.volume = parseFloat(volume);
 }
 
-export function createOneClickBuyButton(
-  price: number,
-  currency: string,
-  tralbumId: string,
-  itemTitle: string,
-  type: string,
-  log: Logger
-): HTMLElement {
-  return createAddToCartButton({ price, currency, tralbumId, itemTitle, type, log });
-}
-
 let activeKeyHandlers: KeyHandlers = {};
 
 export function updateKeyboardHandlers(settings: KeyboardSettings): void {
@@ -240,7 +229,14 @@ export async function initPlayer(
       const minimumPrice = price > 0.0 ? price : CURRENCY_MINIMUMS[currency];
       if (!minimumPrice) return;
 
-      const oneClick = createOneClickBuyButton(minimumPrice, currency, String(trackId), itemTitle, type, log);
+      const oneClick = createAddToCartButton({
+        price: minimumPrice,
+        currency,
+        tralbumId: String(trackId),
+        itemTitle,
+        type,
+        log
+      });
 
       const downloadCol = row.querySelector('.download-col');
       downloadCol.innerHTML = '';
@@ -253,7 +249,14 @@ export async function initPlayer(
     const minimumPrice = price > 0.0 ? price : CURRENCY_MINIMUMS[currency];
     if (!minimumPrice) return;
 
-    const oneClick = createOneClickBuyButton(minimumPrice, currency, String(albumId), itemTitle, type, log);
+    const oneClick = createAddToCartButton({
+      price: minimumPrice,
+      currency,
+      tralbumId: String(albumId),
+      itemTitle,
+      type,
+      log
+    });
 
     const buyItemElement = document.querySelector('ul.tralbumCommands .buyItem.digital h3.hd');
     if (buyItemElement) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,9 +1,7 @@
 import Logger from './logger';
 import { mousedownCallback, extractBandFollowInfo, extractFanTralbumData, createFetchFunction } from './utilities.js';
-import { CURRENCY_MINIMUMS, getTralbumDetails, addAlbumToCart } from './bclient';
-import { createInputButtonPair } from './components/buttons.js';
-import { createShoppingCartItem } from './components/shoppingCart.js';
-import { createPlusSvgIcon } from './components/svgIcons';
+import { CURRENCY_MINIMUMS, getTralbumDetails } from './bclient';
+import { createAddToCartButton } from './components/cartButton';
 import { KeyboardSettings, KeyboardAction, DEFAULT_KEYBOARD_SETTINGS, keyBindingToString } from './types/keyboard.js';
 
 interface KeyCombo {
@@ -178,46 +176,7 @@ export function createOneClickBuyButton(
   type: string,
   log: Logger
 ): HTMLElement {
-  const pair = createInputButtonPair({
-    inputPrefix: '$',
-    inputSuffix: currency,
-    inputPlaceholder: price,
-    buttonChildElement: createPlusSvgIcon() as HTMLElement,
-    onButtonClick: value => {
-      const numericValue = typeof value === 'string' ? parseFloat(value) : value;
-      if (numericValue < price) {
-        log.error('track price too low');
-        return;
-      }
-
-      addAlbumToCart(tralbumId, numericValue, type).then(response => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const cartItem = createShoppingCartItem({
-          itemId: tralbumId,
-          itemName: itemTitle,
-          itemPrice: numericValue,
-          itemCurrency: currency
-        });
-
-        const sidecart = document.querySelector('#sidecart') as HTMLElement;
-        if (sidecart && sidecart.style.display === 'none') {
-          window.location.reload();
-          return;
-        }
-
-        const itemList = document.querySelector('#item_list');
-        if (itemList) {
-          itemList.append(cartItem);
-        }
-      });
-    }
-  });
-  pair.classList.add('one-click-button-container');
-
-  return pair;
+  return createAddToCartButton({ price, currency, tralbumId, itemTitle, type, log });
 }
 
 let activeKeyHandlers: KeyHandlers = {};

--- a/svg/check.svg
+++ b/svg/check.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>

--- a/svg/x.svg
+++ b/svg/x.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>

--- a/test/bclient.test.ts
+++ b/test/bclient.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { addAlbumToCart, getTralbumDetails, getCollectionSummary, hideUnhide, getHiddenItems } from '../src/bclient';
+import {
+  addAlbumToCart,
+  removeAlbumFromCart,
+  getTralbumDetails,
+  getCollectionSummary,
+  hideUnhide,
+  getHiddenItems
+} from '../src/bclient';
 
 describe('bclient', () => {
   afterEach(() => {
@@ -68,6 +75,47 @@ describe('bclient', () => {
         expect.objectContaining({
           method: 'POST'
         })
+      );
+    });
+  });
+
+  describe('removeAlbumFromCart', () => {
+    let fetchSpy: any;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{"success": true}', { status: 200 }));
+    });
+
+    it('should make POST request to cart endpoint with req=del and the item id', async () => {
+      await removeAlbumFromCart('123');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/cart/cb',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            accept: 'application/json, text/javascript, */*; q=0.01',
+            'content-type': 'application/x-www-form-urlencoded',
+            'x-requested-with': 'XMLHttpRequest'
+          }),
+          body: 'req=del&id=123&sync_num=1',
+          mode: 'cors'
+        })
+      );
+    });
+
+    it('should return fetch response', async () => {
+      const response = await removeAlbumFromCart('123');
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(200);
+    });
+
+    it('should use absolute URL when baseUrl is provided', async () => {
+      await removeAlbumFromCart('123', 'https://bandcamp.com');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://bandcamp.com/cart/cb',
+        expect.objectContaining({ method: 'POST' })
       );
     });
   });

--- a/test/cartButton.test.ts
+++ b/test/cartButton.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../src/logger', () => ({
+  default: class MockLogger {
+    info = vi.fn();
+    error = vi.fn();
+    debug = vi.fn();
+    warn = vi.fn();
+  }
+}));
+
+vi.mock('../src/bclient', () => ({
+  addAlbumToCart: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+  removeAlbumFromCart: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })))
+}));
+
+import {
+  getCartItems,
+  isItemInCart,
+  getCartLineItemId,
+  createCartIcons,
+  setCartButtonState,
+  createAddToCartButton
+} from '../src/components/cartButton';
+import { addAlbumToCart, removeAlbumFromCart } from '../src/bclient';
+import Logger from '../src/logger';
+
+const setCartData = (items: Array<{ id?: string | number; item_id: string | number; item_type: string }>) => {
+  const el = document.createElement('div');
+  el.setAttribute('data-cart', JSON.stringify({ items }));
+  document.body.appendChild(el);
+};
+
+const buildButton = (overrides: Record<string, any> = {}) =>
+  createAddToCartButton({
+    price: 1,
+    currency: 'USD',
+    tralbumId: '123',
+    itemTitle: 'Test Album',
+    type: 'a',
+    log: new Logger() as any,
+    ...overrides
+  });
+
+describe('cartButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getCartItems / isItemInCart', () => {
+    it('returns an empty list when there is no cart element', () => {
+      expect(getCartItems()).toEqual([]);
+      expect(isItemInCart('123', 'a')).toBe(false);
+    });
+
+    it('reads items from the [data-cart] blob', () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      expect(getCartItems()).toHaveLength(1);
+    });
+
+    it('matches an item by id and type (coercing id to string)', () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      expect(isItemInCart('123', 'a')).toBe(true);
+      expect(isItemInCart(123, 'a')).toBe(true);
+      expect(isItemInCart('123', 't')).toBe(false);
+      expect(isItemInCart('999', 'a')).toBe(false);
+    });
+
+    it('tolerates malformed cart data', () => {
+      const el = document.createElement('div');
+      el.setAttribute('data-cart', 'not json');
+      document.body.appendChild(el);
+      expect(getCartItems()).toEqual([]);
+    });
+  });
+
+  describe('getCartLineItemId', () => {
+    it('returns the line-item id (not the tralbum id) for a matching item', () => {
+      setCartData([{ id: 555, item_id: 123, item_type: 'a' }]);
+      expect(getCartLineItemId('123', 'a')).toBe(555);
+      expect(getCartLineItemId(123, 'a')).toBe(555);
+    });
+
+    it('returns null when the item is not in the cart', () => {
+      setCartData([{ id: 555, item_id: 123, item_type: 'a' }]);
+      expect(getCartLineItemId('999', 'a')).toBeNull();
+      expect(getCartLineItemId('123', 't')).toBeNull();
+    });
+  });
+
+  describe('createCartIcons', () => {
+    it('renders add, loading, check and remove icon slots', () => {
+      const icons = createCartIcons();
+      expect(icons.querySelectorAll('.bes-cart-icon')).toHaveLength(4);
+      expect(icons.querySelector('.bes-cart-icon-add')).toBeTruthy();
+      expect(icons.querySelector('.bes-cart-icon-loading .bes-cart-spinner')).toBeTruthy();
+      expect(icons.querySelector('.bes-cart-icon-check')).toBeTruthy();
+      expect(icons.querySelector('.bes-cart-icon-remove')).toBeTruthy();
+    });
+  });
+
+  describe('setCartButtonState', () => {
+    it('sets the data attribute and title', () => {
+      const button = document.createElement('button');
+      setCartButtonState(button, 'in-cart');
+      expect(button.dataset.cartState).toBe('in-cart');
+      expect(button.title.toLowerCase()).toContain('remove');
+
+      setCartButtonState(button, 'add');
+      expect(button.dataset.cartState).toBe('add');
+      expect(button.title.toLowerCase()).toContain('add');
+    });
+
+    it('marks the button busy while loading', () => {
+      const button = document.createElement('button');
+      setCartButtonState(button, 'loading');
+      expect(button.dataset.cartState).toBe('loading');
+      expect(button.getAttribute('aria-busy')).toBe('true');
+    });
+  });
+
+  describe('createAddToCartButton', () => {
+    it('starts in the add state when the item is not in the cart', () => {
+      const container = buildButton();
+      const button = container.querySelector('.one-click-button') as HTMLElement;
+      expect(button.dataset.cartState).toBe('add');
+    });
+
+    it('starts in the in-cart state when the item is already in the cart', () => {
+      setCartData([{ item_id: 123, item_type: 'a' }]);
+      const container = buildButton();
+      const button = container.querySelector('.one-click-button') as HTMLElement;
+      expect(button.dataset.cartState).toBe('in-cart');
+    });
+
+    it('shows the loading state immediately on click', () => {
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+
+      button.click();
+
+      expect(button.dataset.cartState).toBe('loading');
+    });
+
+    it('adds to cart and flips to the in-cart state on a successful click', async () => {
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+
+      button.click();
+
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('in-cart'));
+      expect(addAlbumToCart).toHaveBeenCalledWith('123', 1, 'a');
+    });
+
+    it('appends a sidecart row whose × removes the item using the captured line-item id', async () => {
+      const itemList = document.createElement('ol');
+      itemList.id = 'item_list';
+      document.body.appendChild(itemList);
+
+      (addAlbumToCart as any).mockResolvedValueOnce(
+        new Response(JSON.stringify({ items: [{ id: 999, item_id: 123, item_type: 'a' }] }), { status: 200 })
+      );
+
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+
+      button.click();
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('in-cart'));
+
+      const row = document.getElementById('sidecart_item_123');
+      expect(row).toBeTruthy();
+      const del = row!.querySelector('.delete') as HTMLElement;
+      expect(del.style.pointerEvents).not.toBe('none');
+
+      del.click();
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('add'));
+      expect(removeAlbumFromCart).toHaveBeenCalledWith(999);
+      expect(document.getElementById('sidecart_item_123')).toBeNull();
+    });
+
+    it('captures the line-item id from the add response so same-session removal works', async () => {
+      (addAlbumToCart as any).mockResolvedValueOnce(
+        new Response(JSON.stringify({ req: 'add', id: 388964184, sync_num: 100 }), { status: 200 })
+      );
+
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+
+      button.click();
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('in-cart'));
+
+      button.click();
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('add'));
+      expect(removeAlbumFromCart).toHaveBeenCalledWith(388964184);
+    });
+
+    it('removes from cart using the line-item id and reverts to add when clicked while in cart', async () => {
+      setCartData([{ id: 555, item_id: 123, item_type: 'a' }]);
+      const container = buildButton();
+      document.body.appendChild(container);
+      const button = container.querySelector('.one-click-button') as HTMLButtonElement;
+      expect(button.dataset.cartState).toBe('in-cart');
+
+      button.click();
+
+      await vi.waitFor(() => expect(button.dataset.cartState).toBe('add'));
+      expect(removeAlbumFromCart).toHaveBeenCalledWith(555);
+    });
+  });
+});

--- a/test/shoppingCart.test.ts
+++ b/test/shoppingCart.test.ts
@@ -4,14 +4,15 @@ import { createShoppingCartItem } from '../src/components/shoppingCart';
 const base = { itemId: '123', itemName: 'Test Album', itemPrice: 5, itemCurrency: 'USD' };
 
 describe('createShoppingCartItem', () => {
-  it('renders an × delete glyph', () => {
-    const row = createShoppingCartItem(base);
+  it('renders an × delete glyph when onDelete is provided', () => {
+    const row = createShoppingCartItem({ ...base, onDelete: vi.fn() });
     expect(row.querySelector('.delete span')?.textContent).toBe('×');
   });
 
-  it('disables the delete control when no onDelete is provided', () => {
+  it('renders the original ⊘ glyph and disables the control when no onDelete is provided', () => {
     const row = createShoppingCartItem(base);
     const del = row.querySelector('.delete') as HTMLElement;
+    expect(row.querySelector('.delete span')?.textContent).toBe('⊘');
     expect(del.style.pointerEvents).toBe('none');
   });
 

--- a/test/shoppingCart.test.ts
+++ b/test/shoppingCart.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createShoppingCartItem } from '../src/components/shoppingCart';
+
+const base = { itemId: '123', itemName: 'Test Album', itemPrice: 5, itemCurrency: 'USD' };
+
+describe('createShoppingCartItem', () => {
+  it('renders an × delete glyph', () => {
+    const row = createShoppingCartItem(base);
+    expect(row.querySelector('.delete span')?.textContent).toBe('×');
+  });
+
+  it('disables the delete control when no onDelete is provided', () => {
+    const row = createShoppingCartItem(base);
+    const del = row.querySelector('.delete') as HTMLElement;
+    expect(del.style.pointerEvents).toBe('none');
+  });
+
+  it('wires the delete control to onDelete when provided', () => {
+    const onDelete = vi.fn();
+    const row = createShoppingCartItem({ ...base, onDelete });
+    const del = row.querySelector('.delete') as HTMLElement;
+
+    expect(del.style.pointerEvents).not.toBe('none');
+    del.click();
+    expect(onDelete).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #260. The one-click add-to-cart buttons gave no feedback, so it was hard to tell whether an item actually made it into the cart. The button now confirms the action, reflects cart state, and lets you remove items.

- **Add feedback:** tap → quick press + loading **spinner** → the icon pops into a **green check** on a confirmed add. A failed request briefly **shakes**.
- **In-cart on load:** items already in your cart show the green check on page load (read from the page's `[data-cart]` blob).
- **Remove from the button:** hover the check → red **×** → removes the item from the cart without opening it.
- **Remove from the cart row:** the temporary sidecart row now has a working **×** (replacing the old disabled `⊘` control).

## How it works

- Adds `removeAlbumFromCart` to `bclient.ts` — `POST /cart/cb` with `req=del`.
- Removal needs Bandcamp's **cart line-item id** (not the tralbum `item_id`). It's resolved from `[data-cart]` after a reload, and captured from the **add response** (top-level `id`) so same-session removal works without a refresh.
- `getCartItems` prefers the `[data-cart]` element that actually carries line-item ids (the page can have more than one `[data-cart]` element).
- New shared `components/cartButton.ts` (`createAddToCartButton` + icon/state/animation helpers) used by both the track/album one-click buttons (`player.ts`) and the Support BES button (`cart.ts`), removing duplicated add-to-cart logic.
- `createShoppingCartItem` renders a `×` and takes an optional `onDelete`.
- CSS drives the add → loading → in-cart icon swap, the hover-to-remove `×`, and the press/spinner/pop/shake animations via a `data-cart-state` attribute.

## Testing

- `pnpm test` — 363 passing (new coverage for `removeAlbumFromCart`, the `cartButton` component incl. same-session line-item-id capture, and `shoppingCart`).
- `pnpm typecheck`, `pnpm lint` (1 pre-existing unrelated warning in `audioFeatures.ts`), `pnpm build` — clean.
- Manually verified end-to-end on a live cart: add, in-cart-on-load, and remove (same-session and post-reload) all work.

### Known limitation
Removal clears the sidecart row and removes the item server-side, but Bandcamp computes its cart **subtotal/count** from its own internal model, which BES doesn't update — so the subtotal may not refresh until the next page load. Fully syncing that would require hooking Bandcamp's cart model.

Closes #260


https://github.com/user-attachments/assets/af091fd8-4ec5-43bf-8cd0-78c9e8a39522

