### PR TITLE
Fix macOS folder selection error in File System Access API

### DIFF
--- a/src/pages/download.ts
+++ b/src/pages/download.ts
@@ -83,7 +83,8 @@ export function createDownloadAllButton():
     buttonClicked: downloadAllFiles
   });
 
-  downloadAllButton.title = 'Downloads all files to a folder of your choice';
+  downloadAllButton.title =
+    'Downloads all files to a folder of your choice. On macOS, select a subfolder within Downloads.';
   downloadAllButton.style.marginLeft = '10px';
   downloadAllButton.disable();
   downloadAllButton.style.display = 'none';
@@ -222,13 +223,19 @@ async function selectDownloadDirectory(): Promise<FileSystemDirectoryHandle | nu
 
   try {
     const dirHandle = await (window as any).showDirectoryPicker({
-      mode: 'readwrite',
-      startIn: 'downloads'
+      mode: 'readwrite'
     });
     return dirHandle;
   } catch (error) {
     if ((error as Error).name === 'AbortError') {
       log.info('User cancelled directory selection');
+      return null;
+    }
+    if ((error as Error).name === 'NotAllowedError' || (error as Error).name === 'SecurityError') {
+      log.warn('Permission denied for selected folder');
+      showErrorMessage(
+        'Cannot access this folder. On macOS, create a subfolder inside Downloads (e.g., Downloads/Bandcamp) and select that instead.'
+      );
       return null;
     }
     throw error;


### PR DESCRIPTION
## Summary
Fixes #265 - Resolves "contains system files" error when macOS Chrome users select the Downloads folder for batch downloads.

## Problem
After PR #264 introduced the File System Access API for direct folder downloads, macOS users encountered a permission error when selecting their ~/Downloads folder:
> Can't open this folder - bandcamp.com can't open this folder because it contains system files

**Confirmed behavior:**
- ❌ Selecting `~/Downloads` directly → FAILS (macOS security restriction)
- ✅ Creating a subfolder in `~/Downloads` (e.g., `~/Downloads/Bandcamp`) → WORKS
- ✅ Selecting other folders like `/tmp` → WORKS

## Root Cause
macOS system security prevents the File System Access API from accessing top-level system folders like ~/Downloads directly. This is a [known Chromium limitation](https://github.com/electron/electron/issues/42459). However, subfolders within ~/Downloads are allowed.

The code was using `startIn: 'downloads'` which defaulted the picker to the restricted folder, making it likely users would select it.

## Changes
1. **Remove problematic default** (`src/pages/download.ts:224-227`)
   - Removed `startIn: 'downloads'` parameter
   - Picker now opens in last-used or home directory instead of defaulting to restricted ~/Downloads

2. **Improve error handling** (`src/pages/download.ts:234-241`)
   - Catch `NotAllowedError` and `SecurityError` exceptions
   - Show user-friendly error message: "Cannot access this folder. On macOS, create a subfolder inside Downloads (e.g., Downloads/Bandcamp) and select that instead."

3. **Update tooltip** (`src/pages/download.ts:86-87`)
   - Proactively guide macOS users: "Downloads all files to a folder of your choice. On macOS, select a subfolder within Downloads."

## Test Plan
### Manual testing required on macOS Chrome:
- [x] Click "Download All Files" button
- [x] Verify picker doesn't default to ~/Downloads
- [x] Try selecting ~/Downloads directly → should show helpful error message
- [x] Create ~/Downloads/Bandcamp and select it → should work
- [x] Select /tmp → should work

### Cross-platform testing:
- [ ] Windows/Linux Chrome - verify picker still works
- [ ] Firefox - verify fallback to anchor downloads works

🤖 Generated with [Claude Code](https://claude.com/claude-code)