### PR TITLE
Show FindMusic.club played and liked state in the drawer player

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1782,6 +1782,34 @@ body.bes-drawer-expanded #pgBd {
   font-size: 13px;
 }
 
+.bes-player-drawer .bes-track-state-col {
+  width: 38px;
+  text-align: right;
+  padding: 8px 4px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.bes-player-drawer .bes-track-liked,
+.bes-player-drawer .bes-track-played {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+}
+
+.bes-player-drawer .bes-track-row.bes-is-liked .bes-track-liked {
+  display: inline-flex;
+  color: #e0245e;
+}
+
+.bes-player-drawer .bes-track-row.bes-is-played .bes-track-played {
+  display: inline-flex;
+  color: #71717a;
+}
+
 .bes-player-drawer .bes-track-link-col {
   width: 34px;
   text-align: center;

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,6 +6,7 @@ import { initDownloadBackend } from './background/download_backend';
 import { initCartImportBackend } from './background/cart_import_backend';
 import { initFindMusicBackend } from './background/findmusic_backend';
 import { initCacheBackend } from './background/cache_backend';
+import { initPlayedBackend } from './background/played_backend';
 
 (async () => {
   await initConfigBackend();
@@ -16,4 +17,5 @@ import { initCacheBackend } from './background/cache_backend';
   initCartImportBackend();
   initFindMusicBackend();
   initCacheBackend();
+  initPlayedBackend();
 })();

--- a/src/background/config_backend.ts
+++ b/src/background/config_backend.ts
@@ -6,6 +6,7 @@ interface Config {
   displayWaveform: boolean;
   enableMetadataCaching: boolean;
   enableFetchCaching: boolean;
+  enablePlayedCaching: boolean;
   albumPurchasedDuringCheckout: boolean;
   albumOnCheckoutDisabled: boolean;
   albumPurchaseTimeDelaySeconds: number;
@@ -17,6 +18,7 @@ const defaultConfig: Config = {
   displayWaveform: true,
   enableMetadataCaching: true,
   enableFetchCaching: true,
+  enablePlayedCaching: true,
   albumPurchasedDuringCheckout: false,
   albumOnCheckoutDisabled: false,
   albumPurchaseTimeDelaySeconds: 60 * 60 * 24 * 30,
@@ -60,6 +62,8 @@ export async function portListenerCallback(
   if (msg.toggleMetadataCaching) await toggleMetadataCaching(db, log, portState.port);
 
   if (msg.toggleFetchCaching) await toggleFetchCaching(db, log, portState.port);
+
+  if (msg.togglePlayedCaching) await togglePlayedCaching(db, log, portState.port);
 
   if (msg.enableFindMusicCaching) await enableFindMusicCaching(db, log, portState.port);
 
@@ -128,12 +132,22 @@ export async function toggleFetchCaching(db: any, log: Logger, port?: chrome.run
   port?.postMessage({ config: db_config });
 }
 
+export async function togglePlayedCaching(db: any, log: Logger, port?: chrome.runtime.Port): Promise<void> {
+  log.info('toggling played caching');
+
+  const db_config = await db.get('config', 'config');
+  db_config['enablePlayedCaching'] = !db_config['enablePlayedCaching'];
+  await db.put('config', db_config, 'config');
+  port?.postMessage({ config: db_config });
+}
+
 export async function enableFindMusicCaching(db: any, log: Logger, port?: chrome.runtime.Port): Promise<void> {
   log.info('enabling FindMusic.club caching after permission grant');
 
   const db_config = await db.get('config', 'config');
   db_config['enableMetadataCaching'] = true;
   db_config['enableFetchCaching'] = true;
+  db_config['enablePlayedCaching'] = true;
   await db.put('config', db_config, 'config');
   port?.postMessage({ config: db_config });
 }

--- a/src/background/played_backend.ts
+++ b/src/background/played_backend.ts
@@ -31,19 +31,20 @@ async function fetchAlbumTrackState(albumId: string): Promise<TrackState | null>
   return fetchAlbumTrackStateFromAPI(albumId, token);
 }
 
-async function postTrackPlayed(trackId: number): Promise<void> {
+async function postTrackPlayed(trackId: number): Promise<boolean> {
   if (!(await playedCachingEnabled())) {
     log.debug(`Skipping play post for track ${trackId} - played caching disabled`);
-    return;
+    return false;
   }
 
   const token = await getFindMusicToken();
   if (!token) {
     log.debug(`Skipping play post for track ${trackId} - no token available`);
-    return;
+    return false;
   }
 
-  return postTrackPlayedToAPI(trackId, token);
+  await postTrackPlayedToAPI(trackId, token);
+  return true;
 }
 
 export function processRequest(
@@ -63,10 +64,10 @@ export function processRequest(
 
   if (request.contentScriptQuery === 'postTrackPlayed') {
     postTrackPlayed(request.trackId)
-      .then(() => sendResponse({ success: true }))
+      .then(recorded => sendResponse({ success: true, recorded }))
       .catch(error => {
         log.warn(`Unexpected error in postTrackPlayed: ${error.message}`);
-        sendResponse({ success: false, error: error.message });
+        sendResponse({ success: false, recorded: false, error: error.message });
       });
     return true;
   }

--- a/src/background/played_backend.ts
+++ b/src/background/played_backend.ts
@@ -63,10 +63,10 @@ export function processRequest(
 
   if (request.contentScriptQuery === 'postTrackPlayed') {
     postTrackPlayed(request.trackId)
-      .then(recorded => sendResponse({ success: true, recorded }))
+      .then(recorded => sendResponse({ success: recorded }))
       .catch(error => {
         log.warn(`Unexpected error in postTrackPlayed: ${error.message}`);
-        sendResponse({ success: false, recorded: false, error: error.message });
+        sendResponse({ success: false, error: error.message });
       });
     return true;
   }

--- a/src/background/played_backend.ts
+++ b/src/background/played_backend.ts
@@ -43,8 +43,7 @@ async function postTrackPlayed(trackId: number): Promise<boolean> {
     return false;
   }
 
-  await postTrackPlayedToAPI(trackId, token);
-  return true;
+  return postTrackPlayedToAPI(trackId, token);
 }
 
 export function processRequest(

--- a/src/background/played_backend.ts
+++ b/src/background/played_backend.ts
@@ -9,40 +9,33 @@ import { getDB } from '../utilities';
 
 const log = new Logger();
 
-async function playedCachingEnabled(): Promise<boolean> {
+async function tokenWhenPlayedCachingEnabled(): Promise<string | null> {
   const db = await getDB();
   const config = await db.get('config', 'config');
-  return Boolean(config?.enablePlayedCaching);
+
+  if (!config?.enablePlayedCaching) {
+    log.debug('Played caching disabled');
+    return null;
+  }
+
+  const token = await getFindMusicToken();
+  if (!token) log.debug('No FindMusic.club token available');
+
+  return token;
 }
 
 async function fetchAlbumTrackState(albumId: string): Promise<TrackState | null> {
-  if (!(await playedCachingEnabled())) {
-    log.debug(`Skipping track state fetch for album ${albumId} - played caching disabled`);
-    return null;
-  }
+  const token = await tokenWhenPlayedCachingEnabled();
+  if (!token) return null;
 
-  const token = await getFindMusicToken();
-  if (!token) {
-    log.debug(`Skipping track state fetch for album ${albumId} - no token available`);
-    return null;
-  }
-
-  return await fetchAlbumTrackStateFromAPI(albumId, token);
+  return fetchAlbumTrackStateFromAPI(albumId, token);
 }
 
 async function postTrackPlayed(trackId: number): Promise<void> {
-  if (!(await playedCachingEnabled())) {
-    log.debug(`Skipping play post for track ${trackId} - played caching disabled`);
-    return;
-  }
+  const token = await tokenWhenPlayedCachingEnabled();
+  if (!token) return;
 
-  const token = await getFindMusicToken();
-  if (!token) {
-    log.debug(`Skipping play post for track ${trackId} - no token available`);
-    return;
-  }
-
-  return await postTrackPlayedToAPI(trackId, token);
+  return postTrackPlayedToAPI(trackId, token);
 }
 
 export function processRequest(
@@ -52,9 +45,7 @@ export function processRequest(
 ): boolean {
   if (request.contentScriptQuery === 'fetchAlbumTrackState') {
     fetchAlbumTrackState(request.albumId)
-      .then(state => {
-        sendResponse(state);
-      })
+      .then(sendResponse)
       .catch(error => {
         log.warn(`Unexpected error in fetchAlbumTrackState: ${error.message}`);
         sendResponse(null);
@@ -64,9 +55,7 @@ export function processRequest(
 
   if (request.contentScriptQuery === 'postTrackPlayed') {
     postTrackPlayed(request.trackId)
-      .then(() => {
-        sendResponse({ success: true });
-      })
+      .then(() => sendResponse({ success: true }))
       .catch(error => {
         log.warn(`Unexpected error in postTrackPlayed: ${error.message}`);
         sendResponse({ success: false, error: error.message });

--- a/src/background/played_backend.ts
+++ b/src/background/played_backend.ts
@@ -1,0 +1,83 @@
+import Logger from '../logger';
+import {
+  fetchAlbumTrackState as fetchAlbumTrackStateFromAPI,
+  postTrackPlayed as postTrackPlayedToAPI,
+  getFindMusicToken,
+  TrackState
+} from '../clients/findmusic';
+import { getDB } from '../utilities';
+
+const log = new Logger();
+
+async function playedCachingEnabled(): Promise<boolean> {
+  const db = await getDB();
+  const config = await db.get('config', 'config');
+  return Boolean(config?.enablePlayedCaching);
+}
+
+async function fetchAlbumTrackState(albumId: string): Promise<TrackState | null> {
+  if (!(await playedCachingEnabled())) {
+    log.debug(`Skipping track state fetch for album ${albumId} - played caching disabled`);
+    return null;
+  }
+
+  const token = await getFindMusicToken();
+  if (!token) {
+    log.debug(`Skipping track state fetch for album ${albumId} - no token available`);
+    return null;
+  }
+
+  return await fetchAlbumTrackStateFromAPI(albumId, token);
+}
+
+async function postTrackPlayed(trackId: number): Promise<void> {
+  if (!(await playedCachingEnabled())) {
+    log.debug(`Skipping play post for track ${trackId} - played caching disabled`);
+    return;
+  }
+
+  const token = await getFindMusicToken();
+  if (!token) {
+    log.debug(`Skipping play post for track ${trackId} - no token available`);
+    return;
+  }
+
+  return await postTrackPlayedToAPI(trackId, token);
+}
+
+export function processRequest(
+  request: any,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: any) => void
+): boolean {
+  if (request.contentScriptQuery === 'fetchAlbumTrackState') {
+    fetchAlbumTrackState(request.albumId)
+      .then(state => {
+        sendResponse(state);
+      })
+      .catch(error => {
+        log.warn(`Unexpected error in fetchAlbumTrackState: ${error.message}`);
+        sendResponse(null);
+      });
+    return true;
+  }
+
+  if (request.contentScriptQuery === 'postTrackPlayed') {
+    postTrackPlayed(request.trackId)
+      .then(() => {
+        sendResponse({ success: true });
+      })
+      .catch(error => {
+        log.warn(`Unexpected error in postTrackPlayed: ${error.message}`);
+        sendResponse({ success: false, error: error.message });
+      });
+    return true;
+  }
+
+  return false;
+}
+
+export async function initPlayedBackend(): Promise<void> {
+  log.info('starting played backend.');
+  chrome.runtime.onMessage.addListener(processRequest);
+}

--- a/src/background/played_backend.ts
+++ b/src/background/played_backend.ts
@@ -9,31 +9,39 @@ import { getDB } from '../utilities';
 
 const log = new Logger();
 
-async function tokenWhenPlayedCachingEnabled(): Promise<string | null> {
+async function playedCachingEnabled(): Promise<boolean> {
   const db = await getDB();
   const config = await db.get('config', 'config');
 
-  if (!config?.enablePlayedCaching) {
-    log.debug('Played caching disabled');
+  return Boolean(config?.enablePlayedCaching);
+}
+
+async function fetchAlbumTrackState(albumId: string): Promise<TrackState | null> {
+  if (!(await playedCachingEnabled())) {
+    log.debug(`Skipping track state fetch for album ${albumId} - played caching disabled`);
     return null;
   }
 
   const token = await getFindMusicToken();
-  if (!token) log.debug('No FindMusic.club token available');
-
-  return token;
-}
-
-async function fetchAlbumTrackState(albumId: string): Promise<TrackState | null> {
-  const token = await tokenWhenPlayedCachingEnabled();
-  if (!token) return null;
+  if (!token) {
+    log.debug(`Skipping track state fetch for album ${albumId} - no token available`);
+    return null;
+  }
 
   return fetchAlbumTrackStateFromAPI(albumId, token);
 }
 
 async function postTrackPlayed(trackId: number): Promise<void> {
-  const token = await tokenWhenPlayedCachingEnabled();
-  if (!token) return;
+  if (!(await playedCachingEnabled())) {
+    log.debug(`Skipping play post for track ${trackId} - played caching disabled`);
+    return;
+  }
+
+  const token = await getFindMusicToken();
+  if (!token) {
+    log.debug(`Skipping play post for track ${trackId} - no token available`);
+    return;
+  }
 
   return postTrackPlayedToAPI(trackId, token);
 }

--- a/src/clients/findmusic.ts
+++ b/src/clients/findmusic.ts
@@ -150,6 +150,8 @@ export interface TrackState {
   played: number[];
 }
 
+const trackIds = (value: unknown): number[] => (Array.isArray(value) ? value : []);
+
 export async function fetchAlbumTrackState(albumId: string, token: string): Promise<TrackState | null> {
   try {
     const url = new URL(`${process.env.FINDMUSIC_BASE_URL}/api/track-state`);
@@ -175,10 +177,7 @@ export async function fetchAlbumTrackState(albumId: string, token: string): Prom
 
     const data = await response.json();
     log.info(`Successfully fetched track state for album ${albumId}`);
-    return {
-      liked: Array.isArray(data?.liked) ? data.liked : [],
-      played: Array.isArray(data?.played) ? data.played : []
-    };
+    return { liked: trackIds(data?.liked), played: trackIds(data?.played) };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.warn(`Network error fetching track state for album ${albumId}: ${message}`);

--- a/src/clients/findmusic.ts
+++ b/src/clients/findmusic.ts
@@ -144,3 +144,70 @@ export async function postTrackMetadata(
     log.warn(`Network error posting metadata for track ${trackId}: ${message}`);
   }
 }
+
+export interface TrackState {
+  liked: number[];
+  played: number[];
+}
+
+export async function fetchAlbumTrackState(albumId: string, token: string): Promise<TrackState | null> {
+  try {
+    const url = new URL(`${process.env.FINDMUSIC_BASE_URL}/api/track-state`);
+    url.searchParams.set('album_id', albumId);
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    if (response.status === 404 || response.status === 500) {
+      log.debug(`No track state for album ${albumId} (${response.status})`);
+      return null;
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      log.error(`FindMusic.club track state API error: ${response.status} ${errorText}`);
+      return null;
+    }
+
+    const data = await response.json();
+    log.info(`Successfully fetched track state for album ${albumId}`);
+    return {
+      liked: Array.isArray(data?.liked) ? data.liked : [],
+      played: Array.isArray(data?.played) ? data.played : []
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn(`Network error fetching track state for album ${albumId}: ${message}`);
+    return null;
+  }
+}
+
+export async function postTrackPlayed(trackId: number, token: string): Promise<void> {
+  try {
+    const response = await fetch(`${process.env.FINDMUSIC_BASE_URL}/api/played`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        track_id: trackId
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      log.warn(`Failed to post play for track ${trackId}: ${response.status} ${errorText}`);
+      return;
+    }
+
+    log.info(`Successfully posted play for track ${trackId}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn(`Network error posting play for track ${trackId}: ${message}`);
+  }
+}

--- a/src/clients/findmusic.ts
+++ b/src/clients/findmusic.ts
@@ -150,8 +150,6 @@ export interface TrackState {
   played: number[];
 }
 
-const trackIds = (value: unknown): number[] => (Array.isArray(value) ? value : []);
-
 export async function fetchAlbumTrackState(albumId: string, token: string): Promise<TrackState | null> {
   try {
     const url = new URL(`${process.env.FINDMUSIC_BASE_URL}/api/track-state`);
@@ -177,7 +175,10 @@ export async function fetchAlbumTrackState(albumId: string, token: string): Prom
 
     const data = await response.json();
     log.info(`Successfully fetched track state for album ${albumId}`);
-    return { liked: trackIds(data?.liked), played: trackIds(data?.played) };
+    return {
+      liked: Array.isArray(data?.liked) ? data.liked : [],
+      played: Array.isArray(data?.played) ? data.played : []
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.warn(`Network error fetching track state for album ${albumId}: ${message}`);

--- a/src/clients/findmusic.ts
+++ b/src/clients/findmusic.ts
@@ -186,7 +186,7 @@ export async function fetchAlbumTrackState(albumId: string, token: string): Prom
   }
 }
 
-export async function postTrackPlayed(trackId: number, token: string): Promise<void> {
+export async function postTrackPlayed(trackId: number, token: string): Promise<boolean> {
   try {
     const response = await fetch(`${process.env.FINDMUSIC_BASE_URL}/api/played`, {
       method: 'POST',
@@ -202,12 +202,14 @@ export async function postTrackPlayed(trackId: number, token: string): Promise<v
     if (!response.ok) {
       const errorText = await response.text();
       log.warn(`Failed to post play for track ${trackId}: ${response.status} ${errorText}`);
-      return;
+      return false;
     }
 
     log.info(`Successfully posted play for track ${trackId}`);
+    return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.warn(`Network error posting play for track ${trackId}: ${message}`);
+    return false;
   }
 }

--- a/src/components/player/builder.ts
+++ b/src/components/player/builder.ts
@@ -77,20 +77,22 @@ export function buildAlbumBuyButton(tralbumDetails: TralbumDetailsResponse): HTM
   return container;
 }
 
-function buildIndicator(className: string, title: string, icon: string): HTMLElement {
-  const indicator = document.createElement('span');
-  indicator.className = className;
-  indicator.setAttribute('title', title);
-  indicator.innerHTML = icon;
-  return indicator;
-}
-
 function buildTrackStateCell(): HTMLElement {
   const stateCol = document.createElement('td');
   stateCol.className = 'bes-track-state-col';
 
-  stateCol.appendChild(buildIndicator('bes-track-liked', 'Liked on FindMusic.club', heartIcon(12)));
-  stateCol.appendChild(buildIndicator('bes-track-played', 'Played', playedIcon(12)));
+  const likedIndicator = document.createElement('span');
+  likedIndicator.className = 'bes-track-liked';
+  likedIndicator.setAttribute('title', 'Liked on FindMusic.club');
+  likedIndicator.innerHTML = heartIcon(12);
+
+  const playedIndicator = document.createElement('span');
+  playedIndicator.className = 'bes-track-played';
+  playedIndicator.setAttribute('title', 'Played');
+  playedIndicator.innerHTML = playedIcon(12);
+
+  stateCol.appendChild(likedIndicator);
+  stateCol.appendChild(playedIndicator);
 
   return stateCol;
 }

--- a/src/components/player/builder.ts
+++ b/src/components/player/builder.ts
@@ -1,7 +1,7 @@
 import Logger from '../../logger';
 import { TralbumDetailsResponse, CURRENCY_MINIMUMS } from '../../bclient';
 import { createAddToCartButton } from '../cartButton';
-import { prevIcon, nextIcon, playIcon, pauseIcon, volumeIcon } from './icons';
+import { prevIcon, nextIcon, playIcon, pauseIcon, volumeIcon, heartIcon, playedIcon } from './icons';
 import playerCenterMarkup from '../../../html/drawer_player_center.html';
 
 const log = new Logger();
@@ -90,6 +90,10 @@ export function buildTrackTable(tralbumDetails: TralbumDetailsResponse): HTMLEle
     row.className = 'bes-track-row';
     row.setAttribute('rel', `tracknum=${index + 1}`);
 
+    if (track.track_id) {
+      row.dataset.trackId = String(track.track_id);
+    }
+
     const isPlayable = Boolean(track?.streaming_url?.['mp3-128']);
 
     const trackNumCol = document.createElement('td');
@@ -119,6 +123,22 @@ export function buildTrackTable(tralbumDetails: TralbumDetailsResponse): HTMLEle
       timeSpan.textContent = formatDuration(track.duration);
       durationCol.appendChild(timeSpan);
     }
+
+    const stateCol = document.createElement('td');
+    stateCol.className = 'bes-track-state-col';
+
+    const likedIndicator = document.createElement('span');
+    likedIndicator.className = 'bes-track-liked';
+    likedIndicator.setAttribute('title', 'Liked on FindMusic.club');
+    likedIndicator.innerHTML = heartIcon(12);
+
+    const playedIndicator = document.createElement('span');
+    playedIndicator.className = 'bes-track-played';
+    playedIndicator.setAttribute('title', 'Played');
+    playedIndicator.innerHTML = playedIcon(12);
+
+    stateCol.appendChild(likedIndicator);
+    stateCol.appendChild(playedIndicator);
 
     const linkCol = document.createElement('td');
     linkCol.className = 'bes-track-link-col';
@@ -156,6 +176,7 @@ export function buildTrackTable(tralbumDetails: TralbumDetailsResponse): HTMLEle
     row.appendChild(trackNumCol);
     row.appendChild(titleCol);
     row.appendChild(durationCol);
+    row.appendChild(stateCol);
     row.appendChild(linkCol);
     row.appendChild(buyCol);
 

--- a/src/components/player/builder.ts
+++ b/src/components/player/builder.ts
@@ -77,6 +77,24 @@ export function buildAlbumBuyButton(tralbumDetails: TralbumDetailsResponse): HTM
   return container;
 }
 
+function buildIndicator(className: string, title: string, icon: string): HTMLElement {
+  const indicator = document.createElement('span');
+  indicator.className = className;
+  indicator.setAttribute('title', title);
+  indicator.innerHTML = icon;
+  return indicator;
+}
+
+function buildTrackStateCell(): HTMLElement {
+  const stateCol = document.createElement('td');
+  stateCol.className = 'bes-track-state-col';
+
+  stateCol.appendChild(buildIndicator('bes-track-liked', 'Liked on FindMusic.club', heartIcon(12)));
+  stateCol.appendChild(buildIndicator('bes-track-played', 'Played', playedIcon(12)));
+
+  return stateCol;
+}
+
 export function buildTrackTable(tralbumDetails: TralbumDetailsResponse): HTMLElement {
   const table = document.createElement('table');
   table.className = 'bes-tracklist-table';
@@ -124,21 +142,7 @@ export function buildTrackTable(tralbumDetails: TralbumDetailsResponse): HTMLEle
       durationCol.appendChild(timeSpan);
     }
 
-    const stateCol = document.createElement('td');
-    stateCol.className = 'bes-track-state-col';
-
-    const likedIndicator = document.createElement('span');
-    likedIndicator.className = 'bes-track-liked';
-    likedIndicator.setAttribute('title', 'Liked on FindMusic.club');
-    likedIndicator.innerHTML = heartIcon(12);
-
-    const playedIndicator = document.createElement('span');
-    playedIndicator.className = 'bes-track-played';
-    playedIndicator.setAttribute('title', 'Played');
-    playedIndicator.innerHTML = playedIcon(12);
-
-    stateCol.appendChild(likedIndicator);
-    stateCol.appendChild(playedIndicator);
+    const stateCol = buildTrackStateCell();
 
     const linkCol = document.createElement('td');
     linkCol.className = 'bes-track-link-col';

--- a/src/components/player/icons.ts
+++ b/src/components/player/icons.ts
@@ -40,3 +40,11 @@ export function minimizeIcon(size: number): string {
 export function closeIcon(size: number): string {
   return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6 18 18 M18 6 6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"></path></svg>`;
 }
+
+export function heartIcon(size: number): string {
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.5l-1.2-1.08C6.24 15.3 3.5 12.83 3.5 9.78 3.5 7.3 5.46 5.35 7.95 5.35c1.4 0 2.75.65 3.62 1.68l.43.5.43-.5a4.77 4.77 0 0 1 3.62-1.68c2.49 0 4.45 1.95 4.45 4.43 0 3.05-2.74 5.52-7.3 9.65z"></path></svg>`;
+}
+
+export function playedIcon(size: number): string {
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 3a8 8 0 0 0-8 8v6a2.5 2.5 0 0 0 2.5 2.5H8V13H5.5v-2a6.5 6.5 0 0 1 13 0v2H16v6.5h1.5A2.5 2.5 0 0 0 20 17v-6a8 8 0 0 0-8-8z"></path></svg>`;
+}

--- a/src/components/player/loader.ts
+++ b/src/components/player/loader.ts
@@ -47,6 +47,11 @@ async function loadTrackState(albumId: string): Promise<void> {
       return;
     }
 
+    if (String(currentAlbumData?.id) !== albumId) {
+      log.debug(`Track state for album ${albumId} arrived after the drawer moved on`);
+      return;
+    }
+
     applyTrackState(state);
   } catch (error) {
     log.warn(`Failed to load track state for album ${albumId}: ${error}`);

--- a/src/components/player/loader.ts
+++ b/src/components/player/loader.ts
@@ -63,10 +63,15 @@ async function reportPlay(): Promise<void> {
   if (!trackId || reportedPlays.has(trackId)) return;
 
   reportedPlays.add(trackId);
-  markRowPlayed(trackId);
 
   try {
-    await chrome.runtime.sendMessage({ contentScriptQuery: 'postTrackPlayed', trackId });
+    const response = await chrome.runtime.sendMessage({ contentScriptQuery: 'postTrackPlayed', trackId });
+    if (!response?.recorded) {
+      log.debug(`Play of track ${trackId} was not recorded`);
+      return;
+    }
+
+    markRowPlayed(trackId);
   } catch (error) {
     log.warn(`Failed to report play for track ${trackId}: ${error}`);
   }

--- a/src/components/player/loader.ts
+++ b/src/components/player/loader.ts
@@ -248,7 +248,7 @@ export async function loadAlbumIntoDrawer(
 
     attachTrackListHandlers();
     loadTrack(0);
-    loadTrackState(albumId);
+    void loadTrackState(albumId);
 
     log.info(`Album loaded: ${tralbumDetails.title} by ${tralbumDetails.tralbum_artist}`);
   } catch (error) {
@@ -539,9 +539,11 @@ function bindAudioEvents(audio: HTMLAudioElement, playButton: HTMLElement): void
     updateMinimizedPlayButton(isPlaying);
   };
 
+  const showPlaying = reflectPlaying(true);
+
   audio.onplay = () => {
-    reflectPlaying(true)();
-    reportPlay();
+    showPlaying();
+    void reportPlay();
   };
   audio.onpause = reflectPlaying(false);
   audio.onended = () => step(forward, true);

--- a/src/components/player/loader.ts
+++ b/src/components/player/loader.ts
@@ -66,7 +66,7 @@ async function reportPlay(): Promise<void> {
 
   try {
     const response = await chrome.runtime.sendMessage({ contentScriptQuery: 'postTrackPlayed', trackId });
-    if (!response?.recorded) {
+    if (!response?.success) {
       log.debug(`Play of track ${trackId} was not recorded`);
       return;
     }

--- a/src/components/player/loader.ts
+++ b/src/components/player/loader.ts
@@ -9,6 +9,7 @@ import { volumeIcon, mutedVolumeIcon } from './icons';
 import { replaceChildren } from '../dom';
 import { inDrawer, allInDrawer, setText, setStyle } from './query';
 import { streamUrlOf, findPlayableTrackAfter, findPlayableTrackBefore } from './trackSelection';
+import { applyTrackState, markRowPlayed } from './trackState';
 import {
   selectAlbum,
   hasNextAlbum,
@@ -31,6 +32,40 @@ let configPort: chrome.runtime.Port | null = null;
 let waveformEnabled = true;
 
 const ALBUM_LOAD_SETTLE_MS = 300;
+
+const reportedPlays = new Set<number>();
+
+async function loadTrackState(albumId: string): Promise<void> {
+  try {
+    const state = await chrome.runtime.sendMessage({
+      contentScriptQuery: 'fetchAlbumTrackState',
+      albumId
+    });
+
+    if (!state) {
+      log.debug(`No track state available for album ${albumId}`);
+      return;
+    }
+
+    applyTrackState(state);
+  } catch (error) {
+    log.warn(`Failed to load track state for album ${albumId}: ${error}`);
+  }
+}
+
+async function reportPlay(): Promise<void> {
+  const trackId = currentTrack()?.track_id;
+  if (!trackId || reportedPlays.has(trackId)) return;
+
+  reportedPlays.add(trackId);
+  markRowPlayed(trackId);
+
+  try {
+    await chrome.runtime.sendMessage({ contentScriptQuery: 'postTrackPlayed', trackId });
+  } catch (error) {
+    log.warn(`Failed to report play for track ${trackId}: ${error}`);
+  }
+}
 
 function ensureAudioElement(): HTMLAudioElement {
   if (!audioElement) {
@@ -213,6 +248,7 @@ export async function loadAlbumIntoDrawer(
 
     attachTrackListHandlers();
     loadTrack(0);
+    loadTrackState(albumId);
 
     log.info(`Album loaded: ${tralbumDetails.title} by ${tralbumDetails.tralbum_artist}`);
   } catch (error) {
@@ -503,7 +539,10 @@ function bindAudioEvents(audio: HTMLAudioElement, playButton: HTMLElement): void
     updateMinimizedPlayButton(isPlaying);
   };
 
-  audio.onplay = reflectPlaying(true);
+  audio.onplay = () => {
+    reflectPlaying(true)();
+    reportPlay();
+  };
   audio.onpause = reflectPlaying(false);
   audio.onended = () => step(forward, true);
   audio.ontimeupdate = updateProgressBar;

--- a/src/components/player/trackState.ts
+++ b/src/components/player/trackState.ts
@@ -1,0 +1,25 @@
+import { TrackState } from '../../clients/findmusic';
+import { allInDrawer } from './query';
+
+const LIKED_CLASS = 'bes-is-liked';
+const PLAYED_CLASS = 'bes-is-played';
+
+function rowFor(trackId: number): HTMLElement | undefined {
+  return allInDrawer('.bes-track-row').find(row => row.dataset.trackId === String(trackId));
+}
+
+export function applyTrackState(state: TrackState): void {
+  const liked = new Set(state.liked.map(String));
+  const played = new Set(state.played.map(String));
+
+  allInDrawer('.bes-track-row').forEach(row => {
+    const trackId = row.dataset.trackId;
+
+    row.classList.toggle(LIKED_CLASS, Boolean(trackId) && liked.has(trackId as string));
+    row.classList.toggle(PLAYED_CLASS, Boolean(trackId) && played.has(trackId as string));
+  });
+}
+
+export function markRowPlayed(trackId: number): void {
+  rowFor(trackId)?.classList.add(PLAYED_CLASS);
+}

--- a/src/components/player/trackState.ts
+++ b/src/components/player/trackState.ts
@@ -1,25 +1,22 @@
 import { TrackState } from '../../clients/findmusic';
-import { allInDrawer } from './query';
+import { inDrawer, allInDrawer } from './query';
 
 const LIKED_CLASS = 'bes-is-liked';
 const PLAYED_CLASS = 'bes-is-played';
-
-function rowFor(trackId: number): HTMLElement | undefined {
-  return allInDrawer('.bes-track-row').find(row => row.dataset.trackId === String(trackId));
-}
 
 export function applyTrackState(state: TrackState): void {
   const liked = new Set(state.liked.map(String));
   const played = new Set(state.played.map(String));
 
   allInDrawer('.bes-track-row').forEach(row => {
-    const trackId = row.dataset.trackId;
+    const { trackId } = row.dataset;
+    if (!trackId) return;
 
-    row.classList.toggle(LIKED_CLASS, Boolean(trackId) && liked.has(trackId as string));
-    row.classList.toggle(PLAYED_CLASS, Boolean(trackId) && played.has(trackId as string));
+    row.classList.toggle(LIKED_CLASS, liked.has(trackId));
+    row.classList.toggle(PLAYED_CLASS, played.has(trackId));
   });
 }
 
 export function markRowPlayed(trackId: number): void {
-  rowFor(trackId)?.classList.add(PLAYED_CLASS);
+  inDrawer(`.bes-track-row[data-track-id="${trackId}"]`)?.classList.add(PLAYED_CLASS);
 }

--- a/src/findmusic_permission.ts
+++ b/src/findmusic_permission.ts
@@ -51,6 +51,7 @@ button.addEventListener('click', async () => {
       const config = await db.get('config', 'config');
       config.enableMetadataCaching = true;
       config.enableFetchCaching = true;
+      config.enablePlayedCaching = true;
       await db.put('config', config, 'config');
       log.info('Enabled FindMusic.club caching after permission grant');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,12 +262,6 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
   findMusicButton.className = 'bes-drawer-button';
   findMusicButton.textContent = 'Enable FindMusic.club Integration';
 
-  const findMusicSettingRows = [metadataCachingSettingRow, fetchCachingSettingRow, playedCachingSettingRow];
-
-  const showFindMusicSettings = (visible: boolean) => {
-    findMusicSettingRows.forEach(row => (row.style.display = visible ? 'flex' : 'none'));
-  };
-
   const updateButtonText = async () => {
     try {
       const response = await chrome.runtime.sendMessage({
@@ -278,11 +272,15 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
         ? 'Log in to FindMusic.club'
         : 'Enable FindMusic.club Integration';
 
-      showFindMusicSettings(Boolean(response?.granted));
+      metadataCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
+      fetchCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
+      playedCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
     } catch (error) {
       log.error(`Failed to check permissions: ${error}`);
       findMusicButton.textContent = 'Enable FindMusic.club Integration';
-      showFindMusicSettings(false);
+      metadataCachingSettingRow.style.display = 'none';
+      fetchCachingSettingRow.style.display = 'none';
+      playedCachingSettingRow.style.display = 'none';
     }
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,12 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
   findMusicButton.className = 'bes-drawer-button';
   findMusicButton.textContent = 'Enable FindMusic.club Integration';
 
+  const findMusicSettingRows = [metadataCachingSettingRow, fetchCachingSettingRow, playedCachingSettingRow];
+
+  const showFindMusicSettings = (visible: boolean) => {
+    findMusicSettingRows.forEach(row => (row.style.display = visible ? 'flex' : 'none'));
+  };
+
   const updateButtonText = async () => {
     try {
       const response = await chrome.runtime.sendMessage({
@@ -272,15 +278,11 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
         ? 'Log in to FindMusic.club'
         : 'Enable FindMusic.club Integration';
 
-      metadataCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
-      fetchCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
-      playedCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
+      showFindMusicSettings(Boolean(response?.granted));
     } catch (error) {
       log.error(`Failed to check permissions: ${error}`);
       findMusicButton.textContent = 'Enable FindMusic.club Integration';
-      metadataCachingSettingRow.style.display = 'none';
-      fetchCachingSettingRow.style.display = 'none';
-      playedCachingSettingRow.style.display = 'none';
+      showFindMusicSettings(false);
     }
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,10 +160,18 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
     'Share your Bandcamp browsing data with FindMusic.club to help build a music discovery database.'
   );
 
+  const { row: playedCachingSettingRow, toggle: playedCachingToggle } = createToggleSetting(
+    'bes-played-caching-toggle',
+    'Enable played caching',
+    false,
+    'Share which tracks you listen to with FindMusic.club, and show played and liked markers in the player.'
+  );
+
   settingsSection.appendChild(settingsTitle);
   settingsSection.appendChild(waveformSettingRow);
   settingsSection.appendChild(metadataCachingSettingRow);
   settingsSection.appendChild(fetchCachingSettingRow);
+  settingsSection.appendChild(playedCachingSettingRow);
 
   let keyboardSection: HTMLElement | null = null;
 
@@ -209,6 +217,10 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
       fetchCachingToggle.checked = msg.config.enableFetchCaching;
     }
 
+    if (msg.config && typeof msg.config.enablePlayedCaching === 'boolean') {
+      playedCachingToggle.checked = msg.config.enablePlayedCaching;
+    }
+
     if (msg.config && msg.config.keyboardSettings) {
       initKeyboardSection(msg.config.keyboardSettings);
     }
@@ -229,6 +241,10 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
 
   fetchCachingToggle.addEventListener('change', () => {
     config_port.postMessage({ toggleFetchCaching: {} });
+  });
+
+  playedCachingToggle.addEventListener('change', () => {
+    config_port.postMessage({ togglePlayedCaching: {} });
   });
 
   config_port.postMessage({ requestConfig: {} });
@@ -258,11 +274,13 @@ export const initBESDrawer = (config_port: chrome.runtime.Port): void => {
 
       metadataCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
       fetchCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
+      playedCachingSettingRow.style.display = response?.granted ? 'flex' : 'none';
     } catch (error) {
       log.error(`Failed to check permissions: ${error}`);
       findMusicButton.textContent = 'Enable FindMusic.club Integration';
       metadataCachingSettingRow.style.display = 'none';
       fetchCachingSettingRow.style.display = 'none';
+      playedCachingSettingRow.style.display = 'none';
     }
   };
 

--- a/test/config_backend.test.ts
+++ b/test/config_backend.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { updateKeyboardSettings, resetKeyboardSettings } from '../src/background/config_backend';
+import {
+  updateKeyboardSettings,
+  resetKeyboardSettings,
+  togglePlayedCaching,
+  enableFindMusicCaching,
+  setupDB
+} from '../src/background/config_backend';
 import { DEFAULT_KEYBOARD_SETTINGS, KeyboardSettings, KeyboardAction } from '../src/types/keyboard';
 import Logger from '../src/logger';
 
@@ -167,6 +173,88 @@ describe('Config Backend', () => {
       await resetKeyboardSettings(mockDb, mockLog);
 
       expect(mockDb.put).toHaveBeenCalled();
+    });
+  });
+
+  describe('togglePlayedCaching', () => {
+    const makeDb = (config: Record<string, unknown>) => ({
+      get: vi.fn().mockResolvedValue(config),
+      put: vi.fn().mockResolvedValue(undefined)
+    });
+
+    it('should default to enabled on a fresh install', async () => {
+      const mockDb = makeDb(undefined as any);
+
+      await setupDB(mockDb);
+
+      expect(mockDb.put.mock.calls[0][1]).toMatchObject({ enablePlayedCaching: true });
+    });
+
+    it('should keep a user opt-out across restarts', async () => {
+      const mockDb = makeDb({ enablePlayedCaching: false });
+
+      await setupDB(mockDb);
+
+      expect(mockDb.put.mock.calls[0][1]).toMatchObject({ enablePlayedCaching: false });
+    });
+
+    it('should turn played caching off when it is on', async () => {
+      const mockDb = makeDb({ enablePlayedCaching: true });
+      const mockPort = { postMessage: vi.fn() };
+
+      await togglePlayedCaching(mockDb, new Logger(), mockPort as any);
+
+      expect(mockDb.put).toHaveBeenCalledWith('config', { enablePlayedCaching: false }, 'config');
+    });
+
+    it('should turn played caching on when it is off', async () => {
+      const mockDb = makeDb({ enablePlayedCaching: false });
+      const mockPort = { postMessage: vi.fn() };
+
+      await togglePlayedCaching(mockDb, new Logger(), mockPort as any);
+
+      expect(mockDb.put).toHaveBeenCalledWith('config', { enablePlayedCaching: true }, 'config');
+    });
+
+    it('should broadcast the updated config', async () => {
+      const mockDb = makeDb({ enablePlayedCaching: true });
+      const mockPort = { postMessage: vi.fn() };
+
+      await togglePlayedCaching(mockDb, new Logger(), mockPort as any);
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({ config: { enablePlayedCaching: false } });
+    });
+
+    it('should leave the other caching settings alone', async () => {
+      const mockDb = makeDb({
+        enablePlayedCaching: true,
+        enableMetadataCaching: true,
+        enableFetchCaching: true
+      });
+
+      await togglePlayedCaching(mockDb, new Logger());
+
+      expect(mockDb.put).toHaveBeenCalledWith(
+        'config',
+        { enablePlayedCaching: false, enableMetadataCaching: true, enableFetchCaching: true },
+        'config'
+      );
+    });
+
+    it('should be enabled alongside the other caching settings on permission grant', async () => {
+      const mockDb = makeDb({
+        enablePlayedCaching: false,
+        enableMetadataCaching: false,
+        enableFetchCaching: false
+      });
+
+      await enableFindMusicCaching(mockDb, new Logger());
+
+      expect(mockDb.put).toHaveBeenCalledWith(
+        'config',
+        { enablePlayedCaching: true, enableMetadataCaching: true, enableFetchCaching: true },
+        'config'
+      );
     });
   });
 });

--- a/test/findmusic.test.ts
+++ b/test/findmusic.test.ts
@@ -30,7 +30,12 @@ global.fetch = vi.fn();
 
 process.env.FINDMUSIC_BASE_URL = 'https://findmusic.club';
 
-import { exchangeBandcampToken, getFindMusicToken } from '../src/clients/findmusic';
+import {
+  exchangeBandcampToken,
+  getFindMusicToken,
+  fetchAlbumTrackState,
+  postTrackPlayed
+} from '../src/clients/findmusic';
 import { storeFindMusicToken, getFindMusicTokenFromStorage, hasFindMusicPermissions } from '../src/utilities';
 
 describe('FindMusic Client', () => {
@@ -220,6 +225,96 @@ describe('FindMusic Client', () => {
       expect(getFindMusicTokenFromStorageMock).toHaveBeenCalled();
       expect(mockCookiesGet).toHaveBeenCalled();
       expect(storeFindMusicTokenMock).toHaveBeenCalledWith(mockJwtToken);
+    });
+  });
+
+  describe('fetchAlbumTrackState()', () => {
+    it('should request the album track state with a bearer token', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ liked: [4011], played: [4011, 4012] })
+      } as any);
+
+      await fetchAlbumTrackState('123', 'mock-jwt-token');
+
+      expect(global.fetch).toHaveBeenCalledWith('https://findmusic.club/api/track-state?album_id=123', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer mock-jwt-token' }
+      });
+    });
+
+    it('should return the liked and played track ids', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ liked: [4011], played: [4011, 4012] })
+      } as any);
+
+      const state = await fetchAlbumTrackState('123', 'mock-jwt-token');
+
+      expect(state).toEqual({ liked: [4011], played: [4011, 4012] });
+    });
+
+    it('should fall back to empty lists when the response omits them', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({})
+      } as any);
+
+      const state = await fetchAlbumTrackState('123', 'mock-jwt-token');
+
+      expect(state).toEqual({ liked: [], played: [] });
+    });
+
+    it('should return null when the album has no stored state', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({ ok: false, status: 404 } as any);
+
+      const state = await fetchAlbumTrackState('123', 'mock-jwt-token');
+
+      expect(state).toBeNull();
+    });
+
+    it('should return null on a network error', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('offline'));
+
+      const state = await fetchAlbumTrackState('123', 'mock-jwt-token');
+
+      expect(state).toBeNull();
+    });
+  });
+
+  describe('postTrackPlayed()', () => {
+    it('should post the track id with a bearer token', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({ ok: true, status: 200 } as any);
+
+      await postTrackPlayed(4012, 'mock-jwt-token');
+
+      expect(global.fetch).toHaveBeenCalledWith('https://findmusic.club/api/played', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer mock-jwt-token'
+        },
+        body: JSON.stringify({ track_id: 4012 })
+      });
+    });
+
+    it('should swallow a failed response', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'server error'
+      } as any);
+
+      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBeUndefined();
+    });
+
+    it('should swallow a network error', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('offline'));
+
+      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBeUndefined();
     });
   });
 });

--- a/test/findmusic.test.ts
+++ b/test/findmusic.test.ts
@@ -301,20 +301,26 @@ describe('FindMusic Client', () => {
       });
     });
 
-    it('should swallow a failed response', async () => {
+    it('should report that the service accepted the play', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({ ok: true, status: 200 } as any);
+
+      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBe(true);
+    });
+
+    it('should report a rejected play without throwing', async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 500,
         text: async () => 'server error'
       } as any);
 
-      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBeUndefined();
+      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBe(false);
     });
 
-    it('should swallow a network error', async () => {
+    it('should report a network error without throwing', async () => {
       vi.mocked(global.fetch).mockRejectedValue(new Error('offline'));
 
-      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBeUndefined();
+      await expect(postTrackPlayed(4012, 'mock-jwt-token')).resolves.toBe(false);
     });
   });
 });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -268,3 +268,73 @@ describe('BES Drawer', () => {
     expect(drawers.length).toBeLessThanOrEqual(1);
   });
 });
+
+describe('Played caching setting', () => {
+  let mockPort: any;
+  let initBESDrawer: any;
+
+  const buildDrawer = async (granted: boolean) => {
+    document.body.innerHTML = '';
+    mockRuntimeSendMessage.mockResolvedValue({ granted });
+
+    const mainModule = await import('../src/main');
+    initBESDrawer = mainModule.initBESDrawer;
+    initBESDrawer(mockPort as any);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+  };
+
+  const toggle = () => document.getElementById('bes-played-caching-toggle') as HTMLInputElement;
+  const settingRow = () => toggle().closest('.bes-drawer-setting') as HTMLElement;
+  const configListener = () => mockPort.onMessage.addListener.mock.calls[0][0];
+
+  beforeEach(() => {
+    mockPort = {
+      onMessage: { addListener: vi.fn() },
+      postMessage: vi.fn()
+    };
+  });
+
+  afterEach(() => {
+    cleanupTestNodes();
+    vi.clearAllMocks();
+  });
+
+  it('should offer a played caching toggle', async () => {
+    await buildDrawer(true);
+
+    expect(toggle()).toBeTruthy();
+    expect(toggle().type).toBe('checkbox');
+    expect(document.body.textContent).toContain('Enable played caching');
+  });
+
+  it('should hide the setting until FindMusic.club integration is enabled', async () => {
+    await buildDrawer(false);
+
+    expect(settingRow().style.display).toBe('none');
+  });
+
+  it('should show the setting once FindMusic.club integration is enabled', async () => {
+    await buildDrawer(true);
+
+    expect(settingRow().style.display).toBe('flex');
+  });
+
+  it('should reflect the stored setting', async () => {
+    await buildDrawer(true);
+
+    configListener()({ config: { enablePlayedCaching: true } });
+    expect(toggle().checked).toBe(true);
+
+    configListener()({ config: { enablePlayedCaching: false } });
+    expect(toggle().checked).toBe(false);
+  });
+
+  it('should ask the background to toggle the setting when the user flips it', async () => {
+    await buildDrawer(true);
+
+    toggle().dispatchEvent(new Event('change'));
+
+    expect(mockPort.postMessage).toHaveBeenCalledWith({ togglePlayedCaching: {} });
+  });
+});

--- a/test/nativePlayerBuilder.test.ts
+++ b/test/nativePlayerBuilder.test.ts
@@ -276,6 +276,7 @@ describe('NativePlayerBuilder - DOM Structure Creation', () => {
         expect(row.querySelector('.bes-track-num-col')).toBeTruthy();
         expect(row.querySelector('.bes-track-title-col')).toBeTruthy();
         expect(row.querySelector('.bes-track-duration-col')).toBeTruthy();
+        expect(row.querySelector('.bes-track-state-col')).toBeTruthy();
         expect(row.querySelector('.bes-track-link-col')).toBeTruthy();
         expect(row.querySelector('.bes-track-buy-col')).toBeTruthy();
       });
@@ -290,6 +291,34 @@ describe('NativePlayerBuilder - DOM Structure Creation', () => {
       expect(trackLink).toBeTruthy();
       expect(trackLink.href).toContain('/track/track-1');
       expect(trackLink.target).toBe('_blank');
+    });
+
+    it('should tag each row with its track id so FindMusic.club state can be matched', () => {
+      const trackTable = buildTrackTable(mockTralbumDetails);
+
+      const rows = Array.from(trackTable.querySelectorAll<HTMLElement>('.bes-track-row'));
+
+      expect(rows.map(row => row.dataset.trackId)).toEqual(['1001', '1002']);
+    });
+
+    it('should include liked and played indicators on every row', () => {
+      const trackTable = buildTrackTable(mockTralbumDetails);
+
+      const rows = trackTable.querySelectorAll('.bes-track-row');
+      rows.forEach(row => {
+        expect(row.querySelector('.bes-track-liked')).toBeTruthy();
+        expect(row.querySelector('.bes-track-played')).toBeTruthy();
+      });
+    });
+
+    it('should leave rows unmarked until FindMusic.club state arrives', () => {
+      const trackTable = buildTrackTable(mockTralbumDetails);
+
+      const rows = trackTable.querySelectorAll('.bes-track-row');
+      rows.forEach(row => {
+        expect(row.classList.contains('bes-is-liked')).toBe(false);
+        expect(row.classList.contains('bes-is-played')).toBe(false);
+      });
     });
   });
 

--- a/test/played_backend.test.ts
+++ b/test/played_backend.test.ts
@@ -92,25 +92,25 @@ describe('Played Backend', () => {
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).toHaveBeenCalledWith(4012, 'mock-jwt-token');
-      expect(response).toEqual({ success: true, recorded: true });
+      expect(response).toEqual({ success: true });
     });
 
-    it('should say the play was not recorded when played caching is disabled', async () => {
+    it('should not record the play when played caching is disabled', async () => {
       setConfig({ enablePlayedCaching: false });
 
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).not.toHaveBeenCalled();
-      expect(response).toEqual({ success: true, recorded: false });
+      expect(response).toEqual({ success: false });
     });
 
-    it('should say the play was not recorded without a token', async () => {
+    it('should not record the play without a token', async () => {
       vi.mocked(getFindMusicToken).mockResolvedValue(null);
 
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).not.toHaveBeenCalled();
-      expect(response).toEqual({ success: true, recorded: false });
+      expect(response).toEqual({ success: false });
     });
 
     it('should pass on a play the service rejected', async () => {
@@ -118,7 +118,7 @@ describe('Played Backend', () => {
 
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
-      expect(response).toEqual({ success: true, recorded: false });
+      expect(response).toEqual({ success: false });
     });
 
     it('should respond with a failure when the client throws', async () => {
@@ -126,7 +126,7 @@ describe('Played Backend', () => {
 
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
-      expect(response).toEqual({ success: false, recorded: false, error: 'boom' });
+      expect(response).toEqual({ success: false, error: 'boom' });
     });
   });
 });

--- a/test/played_backend.test.ts
+++ b/test/played_backend.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../src/logger', () => ({
+  default: class MockLogger {
+    info = vi.fn();
+    error = vi.fn();
+    debug = vi.fn();
+    warn = vi.fn();
+  }
+}));
+
+vi.mock('../src/clients/findmusic', () => ({
+  fetchAlbumTrackState: vi.fn(),
+  postTrackPlayed: vi.fn(),
+  getFindMusicToken: vi.fn()
+}));
+
+vi.mock('../src/utilities', () => ({
+  getDB: vi.fn()
+}));
+
+import { processRequest } from '../src/background/played_backend';
+import { fetchAlbumTrackState, postTrackPlayed, getFindMusicToken } from '../src/clients/findmusic';
+import { getDB } from '../src/utilities';
+
+const setConfig = (config: Record<string, unknown>) => {
+  vi.mocked(getDB).mockResolvedValue({ get: vi.fn().mockResolvedValue(config) } as any);
+};
+
+const send = (request: Record<string, unknown>): Promise<any> =>
+  new Promise(resolve => {
+    const handled = processRequest(request, {} as any, resolve);
+    if (!handled) resolve('not-handled');
+  });
+
+describe('Played Backend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setConfig({ enablePlayedCaching: true });
+    vi.mocked(getFindMusicToken).mockResolvedValue('mock-jwt-token');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should ignore messages it does not own', () => {
+    expect(processRequest({ contentScriptQuery: 'renderBuffer' }, {} as any, vi.fn())).toBe(false);
+  });
+
+  describe('fetchAlbumTrackState', () => {
+    it('should return the track state for the album', async () => {
+      vi.mocked(fetchAlbumTrackState).mockResolvedValue({ liked: [4011], played: [4012] });
+
+      const response = await send({ contentScriptQuery: 'fetchAlbumTrackState', albumId: '123' });
+
+      expect(fetchAlbumTrackState).toHaveBeenCalledWith('123', 'mock-jwt-token');
+      expect(response).toEqual({ liked: [4011], played: [4012] });
+    });
+
+    it('should not call FindMusic.club when played caching is disabled', async () => {
+      setConfig({ enablePlayedCaching: false });
+
+      const response = await send({ contentScriptQuery: 'fetchAlbumTrackState', albumId: '123' });
+
+      expect(fetchAlbumTrackState).not.toHaveBeenCalled();
+      expect(response).toBeNull();
+    });
+
+    it('should not call FindMusic.club without a token', async () => {
+      vi.mocked(getFindMusicToken).mockResolvedValue(null);
+
+      const response = await send({ contentScriptQuery: 'fetchAlbumTrackState', albumId: '123' });
+
+      expect(fetchAlbumTrackState).not.toHaveBeenCalled();
+      expect(response).toBeNull();
+    });
+
+    it('should respond with null when the client throws', async () => {
+      vi.mocked(fetchAlbumTrackState).mockRejectedValue(new Error('boom'));
+
+      const response = await send({ contentScriptQuery: 'fetchAlbumTrackState', albumId: '123' });
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe('postTrackPlayed', () => {
+    it('should report the play to FindMusic.club', async () => {
+      vi.mocked(postTrackPlayed).mockResolvedValue(undefined);
+
+      const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+
+      expect(postTrackPlayed).toHaveBeenCalledWith(4012, 'mock-jwt-token');
+      expect(response).toEqual({ success: true });
+    });
+
+    it('should not report plays when played caching is disabled', async () => {
+      setConfig({ enablePlayedCaching: false });
+
+      await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+
+      expect(postTrackPlayed).not.toHaveBeenCalled();
+    });
+
+    it('should not report plays without a token', async () => {
+      vi.mocked(getFindMusicToken).mockResolvedValue(null);
+
+      await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+
+      expect(postTrackPlayed).not.toHaveBeenCalled();
+    });
+
+    it('should respond with a failure when the client throws', async () => {
+      vi.mocked(postTrackPlayed).mockRejectedValue(new Error('boom'));
+
+      const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+
+      expect(response).toEqual({ success: false, error: 'boom' });
+    });
+  });
+});

--- a/test/played_backend.test.ts
+++ b/test/played_backend.test.ts
@@ -92,23 +92,25 @@ describe('Played Backend', () => {
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).toHaveBeenCalledWith(4012, 'mock-jwt-token');
-      expect(response).toEqual({ success: true });
+      expect(response).toEqual({ success: true, recorded: true });
     });
 
-    it('should not report plays when played caching is disabled', async () => {
+    it('should say the play was not recorded when played caching is disabled', async () => {
       setConfig({ enablePlayedCaching: false });
 
-      await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+      const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).not.toHaveBeenCalled();
+      expect(response).toEqual({ success: true, recorded: false });
     });
 
-    it('should not report plays without a token', async () => {
+    it('should say the play was not recorded without a token', async () => {
       vi.mocked(getFindMusicToken).mockResolvedValue(null);
 
-      await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+      const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).not.toHaveBeenCalled();
+      expect(response).toEqual({ success: true, recorded: false });
     });
 
     it('should respond with a failure when the client throws', async () => {
@@ -116,7 +118,7 @@ describe('Played Backend', () => {
 
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
-      expect(response).toEqual({ success: false, error: 'boom' });
+      expect(response).toEqual({ success: false, recorded: false, error: 'boom' });
     });
   });
 });

--- a/test/played_backend.test.ts
+++ b/test/played_backend.test.ts
@@ -87,7 +87,7 @@ describe('Played Backend', () => {
 
   describe('postTrackPlayed', () => {
     it('should report the play to FindMusic.club', async () => {
-      vi.mocked(postTrackPlayed).mockResolvedValue(undefined);
+      vi.mocked(postTrackPlayed).mockResolvedValue(true);
 
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
@@ -110,6 +110,14 @@ describe('Played Backend', () => {
       const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
 
       expect(postTrackPlayed).not.toHaveBeenCalled();
+      expect(response).toEqual({ success: true, recorded: false });
+    });
+
+    it('should pass on a play the service rejected', async () => {
+      vi.mocked(postTrackPlayed).mockResolvedValue(false);
+
+      const response = await send({ contentScriptQuery: 'postTrackPlayed', trackId: 4012 });
+
       expect(response).toEqual({ success: true, recorded: false });
     });
 

--- a/test/playerLoader.test.ts
+++ b/test/playerLoader.test.ts
@@ -1194,7 +1194,7 @@ describe('FindMusic.club played and liked state', () => {
   });
 
   it('should mark a track played once the play is recorded', async () => {
-    sendMessage.mockResolvedValue({ success: true, recorded: true });
+    sendMessage.mockResolvedValue({ success: true });
 
     await player.loadAlbumIntoDrawer('123', 'album', false);
     await flush();
@@ -1206,7 +1206,7 @@ describe('FindMusic.club played and liked state', () => {
   });
 
   it('should not mark a track played when played caching is off', async () => {
-    sendMessage.mockResolvedValue({ success: true, recorded: false });
+    sendMessage.mockResolvedValue({ success: false });
 
     await player.loadAlbumIntoDrawer('123', 'album', false);
     await flush();

--- a/test/playerLoader.test.ts
+++ b/test/playerLoader.test.ts
@@ -1122,6 +1122,9 @@ describe('FindMusic.club played and liked state', () => {
       <li class="music-grid-item" data-item-id="album-123">
         <img src="https://example.com/album123.jpg" />
       </li>
+      <li class="music-grid-item" data-item-id="album-456">
+        <img src="https://example.com/album456.jpg" />
+      </li>
     `);
 
     player = await import('../src/components/player/loader');
@@ -1174,6 +1177,20 @@ describe('FindMusic.club played and liked state', () => {
     await flush();
 
     expect(rows().length).toBe(3);
+  });
+
+  it('should not mark rows when the state arrives after the drawer moved to another album', async () => {
+    let resolveState: (state: unknown) => void = () => {};
+    sendMessage.mockImplementationOnce(() => new Promise(resolve => (resolveState = resolve)));
+
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await player.loadAlbumIntoDrawer('456', 'album', false);
+
+    resolveState({ liked: [1], played: [1] });
+    await flush();
+
+    expect(rows()[0].classList.contains('bes-is-liked')).toBe(false);
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(false);
   });
 
   it('should mark a track played locally as soon as it starts playing', async () => {

--- a/test/playerLoader.test.ts
+++ b/test/playerLoader.test.ts
@@ -72,8 +72,9 @@ vi.mock('../src/components/player/builder', () => {
 
   const buildTracklist = (): HTMLElement => {
     const table = document.createElement('table');
-    ['Track 1', 'Track 2', 'Track 3'].forEach(title => {
+    ['Track 1', 'Track 2', 'Track 3'].forEach((title, index) => {
       const row = element('tr', 'bes-track-row');
+      row.dataset.trackId = String(index + 1);
       row.innerHTML = `
         <td class="bes-track-title-col"><span class="bes-track-title">${title}</span></td>
         <td class="bes-track-link-col"><a class="bes-track-link" href="/track">arrow</a></td>
@@ -1082,5 +1083,152 @@ describe('PlayerLoader - Waveform config from the extension', () => {
     audio.dispatchEvent(new Event('canplay'));
 
     expect(lastAnalysisOptions().trackId).toBe(1);
+  });
+});
+
+describe('FindMusic.club played and liked state', () => {
+  let player: typeof import('../src/components/player/loader');
+  let discography: typeof import('../src/discography');
+  let sendMessage: ReturnType<typeof vi.fn>;
+
+  const rows = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll<HTMLElement>('.bes-player-drawer .bes-track-row'));
+
+  const audio = (): HTMLAudioElement => document.querySelector('audio') as HTMLAudioElement;
+
+  const startPlayback = () => audio().dispatchEvent(new Event('play'));
+
+  const playPosts = (): number[] =>
+    sendMessage.mock.calls
+      .map(([message]) => message)
+      .filter(message => message?.contentScriptQuery === 'postTrackPlayed')
+      .map(message => message.trackId);
+
+  const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  beforeEach(async () => {
+    vi.resetModules();
+    sendMessage = vi.fn(async () => null);
+    (globalThis as any).chrome = { runtime: { sendMessage } };
+
+    createDomNodes(`
+      <div class="bes-player-drawer">
+        <div class="bes-player-drawer-player"></div>
+        <div class="bes-player-drawer-tracklist"></div>
+        <img class="bes-player-drawer-album-art" />
+        <div class="bes-player-drawer-transport"></div>
+        <div class="bes-player-drawer-right"></div>
+      </div>
+      <li class="music-grid-item" data-item-id="album-123">
+        <img src="https://example.com/album123.jpg" />
+      </li>
+    `);
+
+    player = await import('../src/components/player/loader');
+    discography = await import('../src/discography');
+    discography.updateDiscographyOrder();
+  });
+
+  afterEach(() => {
+    document.querySelector('audio')?.remove();
+    cleanupTestNodes();
+    vi.clearAllMocks();
+  });
+
+  it('should ask the background for the track state of the album it loads', async () => {
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      contentScriptQuery: 'fetchAlbumTrackState',
+      albumId: '123'
+    });
+  });
+
+  it('should mark liked and played tracks returned by FindMusic.club', async () => {
+    sendMessage.mockResolvedValue({ liked: [2], played: [1, 2] });
+
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    expect(rows().map(row => row.classList.contains('bes-is-liked'))).toEqual([false, true, false]);
+    expect(rows().map(row => row.classList.contains('bes-is-played'))).toEqual([true, true, false]);
+  });
+
+  it('should leave rows unmarked when no state is available', async () => {
+    sendMessage.mockResolvedValue(null);
+
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    rows().forEach(row => {
+      expect(row.classList.contains('bes-is-liked')).toBe(false);
+      expect(row.classList.contains('bes-is-played')).toBe(false);
+    });
+  });
+
+  it('should still load the album when the track state request fails', async () => {
+    sendMessage.mockRejectedValue(new Error('offline'));
+
+    await expect(player.loadAlbumIntoDrawer('123', 'album', false)).resolves.toBeUndefined();
+    await flush();
+
+    expect(rows().length).toBe(3);
+  });
+
+  it('should mark a track played locally as soon as it starts playing', async () => {
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    startPlayback();
+
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(true);
+  });
+
+  it('should report the play to the background', async () => {
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    startPlayback();
+    await flush();
+
+    expect(playPosts()).toEqual([1]);
+  });
+
+  it('should report a play once per track, not on every resume', async () => {
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    startPlayback();
+    startPlayback();
+    startPlayback();
+    await flush();
+
+    expect(playPosts()).toEqual([1]);
+  });
+
+  it('should report each track the listener moves on to', async () => {
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    startPlayback();
+    (document.querySelector('.bes-transport-next') as HTMLElement).click();
+    await flush();
+    startPlayback();
+    await flush();
+
+    expect(playPosts()).toEqual([1, 2]);
+  });
+
+  it('should keep playing when reporting the play fails', async () => {
+    sendMessage.mockRejectedValue(new Error('offline'));
+
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    expect(() => startPlayback()).not.toThrow();
+    await flush();
+
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(true);
   });
 });

--- a/test/playerLoader.test.ts
+++ b/test/playerLoader.test.ts
@@ -1193,13 +1193,28 @@ describe('FindMusic.club played and liked state', () => {
     expect(rows()[0].classList.contains('bes-is-played')).toBe(false);
   });
 
-  it('should mark a track played locally as soon as it starts playing', async () => {
+  it('should mark a track played once the play is recorded', async () => {
+    sendMessage.mockResolvedValue({ success: true, recorded: true });
+
     await player.loadAlbumIntoDrawer('123', 'album', false);
     await flush();
 
     startPlayback();
+    await flush();
 
     expect(rows()[0].classList.contains('bes-is-played')).toBe(true);
+  });
+
+  it('should not mark a track played when played caching is off', async () => {
+    sendMessage.mockResolvedValue({ success: true, recorded: false });
+
+    await player.loadAlbumIntoDrawer('123', 'album', false);
+    await flush();
+
+    startPlayback();
+    await flush();
+
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(false);
   });
 
   it('should report the play to the background', async () => {
@@ -1246,6 +1261,6 @@ describe('FindMusic.club played and liked state', () => {
     expect(() => startPlayback()).not.toThrow();
     await flush();
 
-    expect(rows()[0].classList.contains('bes-is-played')).toBe(true);
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(false);
   });
 });

--- a/test/playerTrackState.test.ts
+++ b/test/playerTrackState.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createDomNodes, cleanupTestNodes } from './utils';
+import { applyTrackState, markRowPlayed } from '../src/components/player/trackState';
+
+const buildTracklist = (trackIds: number[]) =>
+  createDomNodes(`
+    <div class="bes-player-drawer">
+      <table>
+        ${trackIds.map(id => `<tr class="bes-track-row" data-track-id="${id}"></tr>`).join('')}
+      </table>
+    </div>
+  `);
+
+const rows = () => Array.from(document.querySelectorAll<HTMLElement>('.bes-track-row'));
+
+describe('Player track state', () => {
+  afterEach(() => {
+    cleanupTestNodes();
+  });
+
+  it('should mark the liked and played rows by track id', () => {
+    buildTracklist([1001, 1002, 1003]);
+
+    applyTrackState({ liked: [1002], played: [1001, 1002] });
+
+    expect(rows().map(row => row.classList.contains('bes-is-liked'))).toEqual([false, true, false]);
+    expect(rows().map(row => row.classList.contains('bes-is-played'))).toEqual([true, true, false]);
+  });
+
+  it('should clear markers for rows no longer in the state', () => {
+    buildTracklist([1001, 1002]);
+    applyTrackState({ liked: [1001], played: [1001] });
+
+    applyTrackState({ liked: [], played: [1002] });
+
+    expect(rows()[0].classList.contains('bes-is-liked')).toBe(false);
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(false);
+    expect(rows()[1].classList.contains('bes-is-played')).toBe(true);
+  });
+
+  it('should ignore track ids that are not in the tracklist', () => {
+    buildTracklist([1001]);
+
+    expect(() => applyTrackState({ liked: [9999], played: [9999] })).not.toThrow();
+    expect(rows()[0].classList.contains('bes-is-played')).toBe(false);
+  });
+
+  it('should mark a single row played', () => {
+    buildTracklist([1001, 1002]);
+
+    markRowPlayed(1002);
+
+    expect(rows().map(row => row.classList.contains('bes-is-played'))).toEqual([false, true]);
+  });
+
+  it('should ignore a played track that has no row', () => {
+    buildTracklist([1001]);
+
+    expect(() => markRowPlayed(9999)).not.toThrow();
+  });
+
+  it('should only touch rows inside the player drawer', () => {
+    createDomNodes(`
+      <table><tr class="bes-track-row" data-track-id="1001"></tr></table>
+      <div class="bes-player-drawer">
+        <table><tr class="bes-track-row" data-track-id="1002"></tr></table>
+      </div>
+    `);
+
+    applyTrackState({ liked: [1001, 1002], played: [1001, 1002] });
+
+    expect(rows()[0].classList.contains('bes-is-liked')).toBe(false);
+    expect(rows()[1].classList.contains('bes-is-liked')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #233

When the drawer player loads an album it now asks FindMusic.club which of that album's tracks the user has already played or liked, and marks those rows in the tracklist. When a track starts playing, the play is reported back to FindMusic.club and the row is marked once the background confirms it recorded it — so with the setting off no marker appears, matching the fact that nothing is stored.

Like every other FMC feature this is double-gated: the Chrome optional-permission grant **and** a new global **"Enable played caching"** setting, which defaults to on and only appears in the settings drawer once the integration is enabled.

## API

```
GET  {FINDMUSIC_BASE_URL}/api/track-state?album_id=<id>   Authorization: Bearer <token>
     200 -> { "liked": [4011, 4013], "played": [4011, 4012, 4015] }

POST {FINDMUSIC_BASE_URL}/api/played                      Authorization: Bearer <token>
     body { "track_id": 4012 }
```

## Changes

- **Client** (`src/clients/findmusic.ts`) — `fetchAlbumTrackState` and `postTrackPlayed`, following the existing metadata-client conventions (Bearer header, 404/500 treated as a miss, network errors logged and swallowed).
- **Background** (`src/background/played_backend.ts`) — handles the `fetchAlbumTrackState` / `postTrackPlayed` messages, bailing first on `config.enablePlayedCaching` and then on a null token, the same double gate metadata caching uses.
- **Config** — `enablePlayedCaching` (default `true`), a `togglePlayedCaching` mutator, and it is switched on by both `enableFindMusicCaching` and the direct write in `findmusic_permission.ts`.
- **Player** — track rows carry `data-track-id` and a new `td.bes-track-state-col` between duration and the ↗ link, holding a heart and a headphone icon that stay hidden until `bes-is-liked` / `bes-is-played` land on the row. `trackState.ts` applies them drawer-scoped; `loader.ts` fetches state fire-and-forget per album load (ignoring a response that arrives after the drawer moved to another album) and reports plays on `audio.onplay`, deduped per track id so resumes do not re-post.
- **Settings** — an "Enable played caching" toggle, hidden unless FMC permissions are granted.

The heart is read-only for now — `/api/liked` is not wired up, since there is no liked feature yet.

## Testing

`npm test` (660 passing) and `npm run typecheck` are clean. New coverage: `test/played_backend.test.ts` (both gates), `test/playerTrackState.test.ts` (row marking), a "FindMusic.club played and liked state" block in `test/playerLoader.test.ts` (fetch on load, play reported once per track, no marker when the play is not recorded, stale responses ignored, failures never break playback), plus additions to the client, config, builder and settings-drawer tests.

Not verified manually in Chrome — that needs a build, which this repo's workflow avoids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
