### PR TITLE
Remove the unused player drawer overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1000,27 +1000,6 @@ body.bes-drawer-expanded #pgBd {
 }
 
 /* Player Drawer Styles */
-.bes-player-drawer-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: var(--bes-drawer-width);
-  height: 100%;
-  background: transparent;
-  z-index: 10003;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transition:
-    opacity 0.3s ease,
-    visibility 0.3s ease;
-}
-
-.bes-player-drawer-overlay.open {
-  opacity: 1;
-  visibility: visible;
-}
-
 .bes-player-drawer {
   position: fixed;
   top: 0;

--- a/src/components/player/drawer.ts
+++ b/src/components/player/drawer.ts
@@ -45,7 +45,6 @@ function sizeDrawerToPageGutter(): void {
 
 export function createPlayerDrawer(): {
   drawer: HTMLDivElement;
-  overlay: HTMLDivElement;
   openDrawer: () => void;
   closeDrawer: () => void;
   minimizeDrawer: () => void;
@@ -149,8 +148,6 @@ export function createPlayerDrawer(): {
       })
     ]
   });
-
-  const overlay = element('div', { className: 'bes-player-drawer-overlay' });
 
   document.body.classList.add('bes-drawer-host');
 
@@ -276,7 +273,6 @@ export function createPlayerDrawer(): {
 
   return {
     drawer,
-    overlay,
     openDrawer,
     closeDrawer,
     minimizeDrawer,
@@ -288,7 +284,6 @@ export function createPlayerDrawer(): {
 export function getPlayerDrawerElements() {
   return {
     drawer: document.querySelector('.bes-player-drawer') as HTMLDivElement,
-    overlay: document.querySelector('.bes-player-drawer-overlay') as HTMLDivElement,
     playerContainer: document.querySelector('.bes-player-drawer-player') as HTMLDivElement,
     tracklistContainer: document.querySelector('.bes-player-drawer-tracklist') as HTMLDivElement,
     albumArt: document.querySelector('.bes-player-drawer-album-art') as HTMLImageElement,


### PR DESCRIPTION
`createPlayerDrawer` built an overlay element, returned it, and no caller ever appended it to the page — `label_view.ts` destructures the drawer and drops the overlay on the floor. Its CSS was `background: transparent` with `pointer-events: none`, so even if something had appended it, it would have done nothing.

Removed the element, the field on the returned object, its entry in `getPlayerDrawerElements`, and both CSS rules.

Not to be confused with `.bes-drawer-overlay` in `main.ts` — that one belongs to the settings drawer, is appended, and is doing real work. Untouched here.

Split out of #284 so it can land on its own. 662 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)